### PR TITLE
[ADD] mrp_production_no_split_finished_product_move: When most indica…

### DIFF
--- a/mrp_production_no_split_finished_product_move/README.rst
+++ b/mrp_production_no_split_finished_product_move/README.rst
@@ -1,0 +1,14 @@
+MRP production no split finished product move
+=============================================
+
+When most indicated material is produced in an OF, do not split in two
+movement, if the OF is associated to a procurement order.
+
+Credits
+=======
+
+Contributors
+------------
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/mrp_production_no_split_finished_product_move/__init__.py
+++ b/mrp_production_no_split_finished_product_move/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import wizard

--- a/mrp_production_no_split_finished_product_move/__openerp__.py
+++ b/mrp_production_no_split_finished_product_move/__openerp__.py
@@ -28,7 +28,10 @@
         "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
         ],
     'category': 'Warehouse Management',
-    'depends': ['mrp',
+    'depends': ['base',
+                'product',
+                'procurement',
+                'mrp',
                 'mrp_operations_extension'
                 ],
     'data': [],

--- a/mrp_production_no_split_finished_product_move/__openerp__.py
+++ b/mrp_production_no_split_finished_product_move/__openerp__.py
@@ -1,0 +1,36 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'MRP Production No Split Finished Product Move',
+    'version': "1.0",
+    'author': 'OdooMRP team,'
+              'AvanzOSC,'
+              'Serv. Tecnol. Avanzados - Pedro M. Baeza',
+    'website': "http://www.odoomrp.com",
+    "contributors": [
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
+        ],
+    'category': 'Warehouse Management',
+    'depends': ['mrp',
+                'mrp_operations_extension'
+                ],
+    'data': [],
+    'installable': True,
+}

--- a/mrp_production_no_split_finished_product_move/tests/__init__.py
+++ b/mrp_production_no_split_finished_product_move/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import test_mrp_production_no_split_finished_product_move

--- a/mrp_production_no_split_finished_product_move/tests/test_mrp_production_no_split_finished_product_move.py
+++ b/mrp_production_no_split_finished_product_move/tests/test_mrp_production_no_split_finished_product_move.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+import openerp.tests.common as common
+
+
+class TestMrpProductionNoSplitFinishedProductMove(common.TransactionCase):
+
+    def setUp(self):
+        super(TestMrpProductionNoSplitFinishedProductMove, self).setUp()
+        self.product_model = self.env['product.product']
+        self.mrp_bom_model = self.env['mrp.bom']
+        self.mrp_bom_line_model = self.env['mrp.bom.line']
+        self.customer_model = self.env['res.partner']
+        self.sale_model = self.env['sale.order']
+        self.procurement_model = self.env['procurement.order']
+        self.procurement_rule_model = self.env['procurement.rule']
+        self.produce_model = self.env['mrp.product.produce']
+        self.produce_line_model = self.env['mrp.product.produce.line']
+        product_vals = {
+            'name': 'Product to produce',
+            'standard_price': 20.0,
+            'list_price': 30.0,
+            'type': 'product',
+            'route_ids': [
+                (6, 0,
+                 [self.env.ref('mrp.route_warehouse0_manufacture').id,
+                  self.env.ref('stock.route_warehouse0_mto').id])]}
+        self.produce_product = self.product_model.create(product_vals)
+        product_vals = {
+            'name': 'Product to consume',
+            'standard_price': 2.0,
+            'list_price': 3.0,
+            'type': 'product'}
+        self.consume_product = self.product_model.create(product_vals)
+        bom_vals = {'product_tmpl_id': self.produce_product.product_tmpl_id.id,
+                    'product_id': self.produce_product.id}
+        self.bom = self.mrp_bom_model.create(bom_vals)
+        bom_line_vals = {'product_id': self.consume_product.id,
+                         'bom_id': self.bom.id}
+        self.mrp_bom_line_model.create(bom_line_vals)
+        customer_vals = {'name': 'Customer-1',
+                         'customer': True}
+        self.customer = self.customer_model.create(customer_vals)
+        sale_vals = {
+            'partner_id': self.customer.id,
+            'partner_shipping_id': self.customer.id,
+            'partner_invoice_id': self.customer.id,
+            'pricelist_id': self.env.ref('product.list0').id}
+        sale_line_vals = {
+            'product_id': self.produce_product.id,
+            'name': self.produce_product.name,
+            'product_uos_qty': 1,
+            'product_uom': self.produce_product.uom_id.id,
+            'price_unit': self.produce_product.list_price}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+
+    def test_confirm_sale_for_produce_product(self):
+        self.sale_order.action_button_confirm()
+        cond = [('origin', '=', self.sale_order.name),
+                ('product_id', '=', self.produce_product.id)]
+        procurement = self.procurement_model.search(cond)
+        self.assertEqual(
+            len(procurement), 1,
+            "Procurement not generated for produce product type")
+        cond = [('group_id', '=', procurement.group_id.id),
+                ('product_id', '=', self.produce_product.id),
+                ('state', '=', 'confirmed')]
+        procurement2 = self.procurement_model.search(cond)
+        self.assertEqual(
+            len(procurement2), 1,
+            "Procurement2 not generated for produce product type")
+        cond = [('name', 'ilike', 'Manufacture')]
+        rule = self.procurement_rule_model.search(cond, limit=1)
+        self.assertEqual(
+            len(rule), 1, "Rule not found for MANUFACTURE")
+        procurement2.write({'bom_id': self.bom.id,
+                            'rule_id': rule.id})
+        procurement2.run()
+        self.assertTrue(
+            bool(procurement2.production_id),
+            "MRP production no generated for procurement2")
+        procurement2.production_id.force_production()
+        produce_vals = {'product_qty': 5,
+                        'mode': 'consume_produce',
+                        'product_id': self.produce_product.id,
+                        'track_production': False}
+        self.produce = self.produce_model.create(produce_vals)
+        produce_line_vals = {'product_id': self.consume_product.id,
+                             'product_qty': 1,
+                             'produce_id': self.produce.id,
+                             'track_production': False}
+        self.produce_line_model.create(produce_line_vals)
+        self.produce.with_context(
+            active_id=procurement2.production_id.id).do_produce()
+        self.assertEqual(
+            len(procurement2.production_id.move_created_ids2), 1,
+            "It has created more than one product to produce movement")

--- a/mrp_production_no_split_finished_product_move/wizard/__init__.py
+++ b/mrp_production_no_split_finished_product_move/wizard/__init__.py
@@ -1,0 +1,6 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from . import mrp_product_produce
+from . import mrp_work_order_produce

--- a/mrp_production_no_split_finished_product_move/wizard/mrp_product_produce.py
+++ b/mrp_production_no_split_finished_product_move/wizard/mrp_product_produce.py
@@ -1,0 +1,27 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from openerp import api, models
+
+
+class MrpProductProduce(models.TransientModel):
+    _inherit = 'mrp.product.produce'
+
+    @api.multi
+    def do_produce(self):
+        self.ensure_one()
+        if self.mode == 'consume_produce':
+            production_id = self.env.context.get('active_id', False)
+            if production_id:
+                cond = [('production_id', '=', production_id)]
+                procs = self.env['procurement.order'].search(cond, limit=1)
+                if procs:
+                    production = self.env['mrp.production'].browse(
+                        production_id)
+                    move = production.move_created_ids.filtered(
+                        lambda x: x.product_id == production.product_id)
+                    if move and self.product_qty > move[0].product_uom_qty:
+                        move[0].write({'product_uom_qty': self.product_qty})
+        return super(MrpProductProduce, self).do_produce()

--- a/mrp_production_no_split_finished_product_move/wizard/mrp_work_order_produce.py
+++ b/mrp_production_no_split_finished_product_move/wizard/mrp_work_order_produce.py
@@ -1,0 +1,38 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from openerp import api, models
+
+
+class MrpWorkOrderProduce(models.TransientModel):
+    _inherit = 'mrp.work.order.produce'
+
+    @api.multi
+    def do_produce(self):
+        self.ensure_one()
+        work_line = self.env['mrp.production.workcenter.line'].browse(
+            self.env.context.get("active_id"))
+        cond = [('production_id', '=', work_line.production_id.id)]
+        procs = self.env['procurement.order'].search(cond, limit=1)
+        if procs:
+            move = work_line.production_id.move_created_ids.filtered(
+                lambda x: x.product_id == work_line.production_id.product_id)
+            if move and self.product_qty > move[0].product_uom_qty:
+                move[0].write({'product_uom_qty': self.product_qty})
+        return super(MrpWorkOrderProduce, self).do_produce()
+
+    @api.multi
+    def do_consume_produce(self):
+        self.ensure_one()
+        work_line = self.env['mrp.production.workcenter.line'].browse(
+            self.env.context.get("active_id"))
+        cond = [('production_id', '=', work_line.production_id.id)]
+        procs = self.env['procurement.order'].search(cond, limit=1)
+        if procs:
+            move = work_line.production_id.move_created_ids.filtered(
+                lambda x: x.product_id == work_line.production_id.product_id)
+            if move and self.product_qty > move[0].product_uom_qty:
+                move[0].write({'product_uom_qty': self.product_qty})
+        return super(MrpWorkOrderProduce, self).do_consume_produce()


### PR DESCRIPTION
…ted material is produced in an OF, do not split in two movement, if the OF is associated to a procurement order.

Nuevo módulo para que cuando en una OF se produce más material del indicado a producir, en el último movimiento no hacer split en 2 del movimiento, sino generar un único movimiento con la cantidad correcta que al ser realizado creará un único quant.
Este nuevo requerimiento se ha solicitado en la Reclamación CLM0284-Crea demasiados tests de calidad (split de stock.move en producto a producir en la OF cuando se produce más cantidad que la de la OF).