### PR TITLE
[IMP] crm_claim_filter: In combo of customers in addition to name, VA…

### DIFF
--- a/crm_claim_filter/models/__init__.py
+++ b/crm_claim_filter/models/__init__.py
@@ -2,3 +2,4 @@
 # (c) 2015 Alfredo de la Fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from . import crm_claim
+from . import res_partner

--- a/crm_claim_filter/models/res_partner.py
+++ b/crm_claim_filter/models/res_partner.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, api
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        if args is None:
+            args = []
+        partners = super(ResPartner, self).name_search(
+            name, args=args, operator=operator, limit=limit)
+        ids = [x[0] for x in partners]
+        if name:
+            ids2 = self.search(
+                [('vat', operator, name)] + args, limit=limit).ids
+            ids = list(set(ids + ids2))
+        return self.browse(ids).name_get()

--- a/crm_claim_filter/tests/test_crm_claim_filter.py
+++ b/crm_claim_filter/tests/test_crm_claim_filter.py
@@ -9,6 +9,7 @@ class TestCrmClaimFilter(common.TransactionCase):
     def setUp(self):
         super(TestCrmClaimFilter, self).setUp()
         self.claim_model = self.env['crm.claim']
+        self.partner_model = self.env['res.partner']
         self.partner = self.env.ref('base.res_partner_2')
         self.partner.write({'vat': 'ESA12345674',
                             'mobile': '943943943'})
@@ -23,3 +24,9 @@ class TestCrmClaimFilter(common.TransactionCase):
         self.assertEqual(
             claim.mobile, self.partner.mobile,
             'VAT of the claim, does not match with partner vat')
+
+    def test_crm_claim_filter_partner_search(self):
+        partners = self.partner_model.name_search(
+            name='ESA12345674', args=None)
+        self.assertNotEqual(
+            len(partners), 0, 'Partner was not found when searching for vat')


### PR DESCRIPTION
…T Search.

Se ha modificado este módulo, para que en el combo de cliente, que además de hacer la búsqueda por nombre, se realice la búsqueda también por CIF en el mismo campo.