### PR TITLE
[ADD] New module crm_claim_channel

### DIFF
--- a/crm_claim_channel/README.rst
+++ b/crm_claim_channel/README.rst
@@ -1,0 +1,20 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=================
+Crm Claim Channel
+=================
+
+This module create new three field on claims. This fields allow you to control
+the input channel, response channel and the source of claims.
+
+
+Credits
+=======
+
+
+Contributors
+------------
+* Esther Martín <esthermartin@avanzosc.es>
+* Ana Juaristi <anajuaristi@avanzosc.es>

--- a/crm_claim_channel/__init__.py
+++ b/crm_claim_channel/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import models

--- a/crm_claim_channel/__openerp__.py
+++ b/crm_claim_channel/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Crm Claim Channel",
+    "version": "8.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Esther Martín <esthermartin@avanzosc.es>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+    ],
+    "depends": [
+        "crm_lead_marketing_info",
+    ],
+    "category": "Customer Relationship Management",
+    "data": [
+        "views/crm_claim_view.xml",
+    ],
+    "installable": True
+}

--- a/crm_claim_channel/models/__init__.py
+++ b/crm_claim_channel/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import crm_claim

--- a/crm_claim_channel/models/crm_claim.py
+++ b/crm_claim_channel/models/crm_claim.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import fields, models
+
+
+class CrmClaim(models.Model):
+    _inherit = 'crm.claim'
+
+    input_channel = fields.Many2one(comodel_name='crm.tracking.medium',
+                                    string='Input channel')
+    response_channel = fields.Many2one(comodel_name='crm.tracking.medium',
+                                       string='Response channel')
+    source_id = fields.Many2one(comodel_name='crm.tracking.source',
+                                string='Source')

--- a/crm_claim_channel/views/crm_claim_view.xml
+++ b/crm_claim_channel/views/crm_claim_view.xml
@@ -1,0 +1,19 @@
+<openerp>
+    <data>
+        <record id="crm_claim_close_view_form" model="ir.ui.view" >
+            <field name="name">crm.claim.close.form</field>
+            <field name="model">crm.claim</field>
+            <field name="inherit_id" ref="crm_claim.crm_case_claims_form_view" />
+            <field name="arch" type="xml">
+                <separator string="Claim/Action Description" position="before">
+                <separator string="Channel info" colspan="2"/>
+                <group>
+                    <field name="input_channel"/>
+                    <field name="response_channel"/>
+                    <field name="source_id"/>
+                </group>
+                </separator>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Requieren además de los ya añadidos, los siguientes campos en la reclamación:

- Canal entrada: many2one a tabla canal (creada para leads, no hace falta crear nueva)
- Canal respuesta: many2one a tabla canal
- Origen: many2one a tabla origen (creada para leads, no hace falta crear nueva)

---

Este módulo, sería genérico ya que el origen de la reclamación, o canal, deberían ser campos que ya incluya la reclamación. 
Crearía un módulo claim_channel o claim_origin.
Por si acaso, mirar en OCA si existe alguno que podamos aprovechar. 