### PR TITLE
[ADD] new module <crm_claim_team>

### DIFF
--- a/crm_claim_team/README.rst
+++ b/crm_claim_team/README.rst
@@ -1,0 +1,23 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
+Crm Claim Team
+==============
+
+This module controls in claim stages if 'common to all teams' is not checked,
+you can choose which teams applies the stage.
+
+It also control in sales teams if the team manage the claims and you can see
+their claim stages. 
+
+
+Credits
+=======
+
+
+Contributors
+------------
+* Esther Martín <esthermartin@avanzosc.es>
+* Ana Juaristi <anajuaristi@avanzosc.es>

--- a/crm_claim_team/__init__.py
+++ b/crm_claim_team/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import models

--- a/crm_claim_team/__openerp__.py
+++ b/crm_claim_team/__openerp__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Crm Claim Team",
+    "version": "8.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Esther Martín <esthermartin@avanzosc.es>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+    ],
+    "depends": [
+        "crm_claim",
+        "sales_team",
+    ],
+    "category": "Customer Relationship Management",
+    "data": [
+        "views/crm_claim_view.xml",
+        "views/sales_team_view.xml",
+    ],
+    "installable": True
+}

--- a/crm_claim_team/models/__init__.py
+++ b/crm_claim_team/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import crm_case_section

--- a/crm_claim_team/models/crm_case_section.py
+++ b/crm_claim_team/models/crm_case_section.py
@@ -10,7 +10,7 @@ class CrmCaseSection(models.Model):
 
     @api.multi
     def _default_claim_stage(self):
-        ids = self.env['crm.claim.stage'].search([('case_default', '=', 1)])
+        ids = self.env['crm.claim.stage'].search([('case_default', '=', True)])
         return ids
 
     claim_stage_ids = fields.Many2many(

--- a/crm_claim_team/models/crm_case_section.py
+++ b/crm_claim_team/models/crm_case_section.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, fields, models
+
+
+class CrmCaseSection(models.Model):
+    _inherit = 'crm.case.section'
+
+    @api.multi
+    def _default_claim_stage(self):
+        ids = self.env['crm.claim.stage'].search([('case_default', '=', 1)])
+        return ids
+
+    claim_stage_ids = fields.Many2many(
+        comodel_name='crm.claim.stage', relation='section_claim_stage_rel',
+        column1='section_id', column2='stage_id', string='Claim stages',
+        default=_default_claim_stage)
+    use_claims = fields.Boolean(string='Claims', default=True)

--- a/crm_claim_team/models/crm_case_section.py
+++ b/crm_claim_team/models/crm_case_section.py
@@ -10,8 +10,9 @@ class CrmCaseSection(models.Model):
 
     @api.multi
     def _default_claim_stage(self):
-        ids = self.env['crm.claim.stage'].search([('case_default', '=', True)])
-        return ids
+        stages = self.env['crm.claim.stage'].search(
+            [('case_default', '=', True)])
+        return stages
 
     claim_stage_ids = fields.Many2many(
         comodel_name='crm.claim.stage', relation='section_claim_stage_rel',

--- a/crm_claim_team/tests/__init__.py
+++ b/crm_claim_team/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_crm_claim_team

--- a/crm_claim_team/tests/test_crm_claim_team.py
+++ b/crm_claim_team/tests/test_crm_claim_team.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import openerp.tests.common as common
+
+
+class TestCrmClaimTeam(common.TransactionCase):
+
+    def setUp(self):
+        super(TestCrmClaimTeam, self).setUp()
+        self.case_section_obj = self.env['crm.case.section']
+        self.stage1 = self.env.ref('crm_claim.stage_claim1')
+        self.stage2 = self.env.ref('crm_claim.stage_claim2')
+        self.stage3 = self.env.ref('crm_claim.stage_claim3')
+        self.stage4 = self.env.ref('crm_claim.stage_claim5')
+
+    def test_crm_claim_team_default_stage(self):
+        self.stage1.case_default = False
+        self.stage2.case_default = False
+        self.stage3.case_default = True
+        self.stage4.case_default = True
+        self.case_section = self.case_section_obj.create(
+            {'name': 'Claim1'})
+        self.assertEqual(2, len(self.case_section.claim_stage_ids),
+                         'Not the same number of stages')

--- a/crm_claim_team/views/crm_claim_view.xml
+++ b/crm_claim_team/views/crm_claim_view.xml
@@ -1,7 +1,7 @@
 <openerp>
     <data>
-        <record id="pesa_crm_claim_stage_view_form" model="ir.ui.view">
-            <field name="name">pesa.crm.claim.stage.form</field>
+        <record id="crm_claim_stage_view_form" model="ir.ui.view">
+            <field name="name">crm.claim.stage.form</field>
             <field name="model">crm.claim.stage</field>
             <field name="inherit_id" ref="crm_claim.crm_claim_stage_form" />
             <field name="arch" type="xml">

--- a/crm_claim_team/views/crm_claim_view.xml
+++ b/crm_claim_team/views/crm_claim_view.xml
@@ -1,0 +1,20 @@
+<openerp>
+    <data>
+        <record id="pesa_crm_claim_stage_view_form" model="ir.ui.view">
+            <field name="name">pesa.crm.claim.stage.form</field>
+            <field name="model">crm.claim.stage</field>
+            <field name="inherit_id" ref="crm_claim.crm_claim_stage_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='sequence']/.." position="after">
+                    <group>
+                        <group attrs="{'invisible':[('case_default','=',True)]}">
+                            <separator string="Sections" colspan="2"/>
+                            <field name="section_ids" nolabel="1"/>
+                        </group>
+                        <group></group>
+                    </group>
+                </xpath> 
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/crm_claim_team/views/sales_team_view.xml
+++ b/crm_claim_team/views/sales_team_view.xml
@@ -1,0 +1,18 @@
+<openerp>
+    <data>
+        <record id="pesa_crm_case_section_view_form" model="ir.ui.view">
+            <field name="name">pesa.crm.case.section.form</field>
+            <field name="model">crm.case.section</field>
+            <field name="inherit_id" ref="sales_team.crm_case_section_view_form" />
+            <field name="arch" type="xml">
+                <label for="use_opportunities" position="after">
+                    <field name="use_claims"/><label for="use_claims" string="Claims"/>
+                </label>
+                <field name="stage_ids" position="after">
+                    <separator string="Claim stages for this Sales Team" colspan="2"/>
+                    <field name="claim_stage_ids"/>
+                </field> 
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/crm_claim_team/views/sales_team_view.xml
+++ b/crm_claim_team/views/sales_team_view.xml
@@ -1,16 +1,19 @@
 <openerp>
     <data>
-        <record id="pesa_crm_case_section_view_form" model="ir.ui.view">
-            <field name="name">pesa.crm.case.section.form</field>
+        <record id="crm_claim_team_section_view_form" model="ir.ui.view">
+            <field name="name">crm.claim.team.section.form</field>
             <field name="model">crm.case.section</field>
             <field name="inherit_id" ref="sales_team.crm_case_section_view_form" />
             <field name="arch" type="xml">
                 <label for="use_opportunities" position="after">
-                    <field name="use_claims"/><label for="use_claims" string="Claims"/>
+                    <field name="use_claims"/>
+                    <label for="use_claims" string="Claims"/>
                 </label>
                 <field name="stage_ids" position="after">
-                    <separator string="Claim stages for this Sales Team" colspan="2"/>
-                    <field name="claim_stage_ids"/>
+                    <group attrs="{'invisible':[('use_claims','=',False)]}">
+                        <separator string="Claim stages for this Sales Team" colspan="2"/>
+                        <field name="claim_stage_ids" nolabel="1"/>
+                    </group>
                 </field> 
             </field>
         </record>


### PR DESCRIPTION
Vemos que en las etapas de reclamación, existe un combo "aplicar a todos los equipos" pero cuando no está clickado debería salir el campo para poder seleccionar los equipos a los que aplica.

Aparte en equipos de venta debería poder seleccionarse también "claim" aparte de presupuesto, lead y oportunidad
En el listado many2many a etapas, deberían verse también las que aplican a claim

Aunque se ha detectado en Pesa, esto debería ser genérico del tipo claim_team o algo así.