### PR TITLE
[ADD] sale_order_line_performance: Define "performance" field in sale…

### DIFF
--- a/sale_order_line_performance/README.rst
+++ b/sale_order_line_performance/README.rst
@@ -1,0 +1,22 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===========================
+Sale order line performance
+===========================
+
+* In the product it has been added the field "performance": estimated time for
+  completion of the task. Visible if the product is a "service".
+* By selecting the product in the sale order line, It is brought product
+  performance to the sale order line.
+* The calculation of the sales order line subtotal = quantity * performance *
+  price unit
+
+Credits
+=======
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/sale_order_line_performance/__init__.py
+++ b/sale_order_line_performance/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models

--- a/sale_order_line_performance/__openerp__.py
+++ b/sale_order_line_performance/__openerp__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# © 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Sale Order Line Performance",
+    "version": "8.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es",
+    ],
+    "category": "Sales Management",
+    "depends": [
+        "sale",
+    ],
+    "data": [
+        "views/product_product_view.xml",
+        "views/sale_order_view.xml",
+    ],
+    "installable": True,
+}

--- a/sale_order_line_performance/i18n/es.po
+++ b/sale_order_line_performance/i18n/es.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_order_line_performance
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-01-19 10:16+0000\n"
+"PO-Revision-Date: 2016-01-19 11:17+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: sale_order_line_performance
+#: help:product.product,performance:0 help:sale.order.line,performance:0
+msgid "Estimated time for completion the task"
+msgstr "Tiempo estimado para completar la tarea"
+
+#. module: sale_order_line_performance
+#: field:product.product,performance:0 field:sale.order.line,performance:0
+msgid "Performance"
+msgstr "Rendimiento"
+
+#. module: sale_order_line_performance
+#: model:ir.model,name:sale_order_line_performance.model_product_product
+msgid "Product"
+msgstr "Producto"
+
+#. module: sale_order_line_performance
+#: model:ir.model,name:sale_order_line_performance.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea pedido de venta"

--- a/sale_order_line_performance/models/__init__.py
+++ b/sale_order_line_performance/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import product_product
+from . import sale_order_line

--- a/sale_order_line_performance/models/product_product.py
+++ b/sale_order_line_performance/models/product_product.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# © 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    performance = fields.Float(
+        'Performance', help='Estimated time for completion the task')

--- a/sale_order_line_performance/models/sale_order_line.py
+++ b/sale_order_line_performance/models/sale_order_line.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# © 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.model
+    def _calc_line_quantity(self, line):
+        qty = super(SaleOrderLine, self)._calc_line_quantity(line)
+        if line.performance:
+            qty = qty * line.performance
+        return qty
+
+    performance = fields.Float(
+        'Performance', help='Estimated time for completion the task')
+
+    @api.multi
+    def product_id_change(
+            self, pricelist, product, qty=0, uom=False, qty_uos=0, uos=False,
+            name='', partner_id=False, lang=False, update_tax=True,
+            date_order=False, packaging=False, fiscal_position=False,
+            flag=False):
+        res = super(SaleOrderLine, self). product_id_change(
+            pricelist, product, qty=qty, uom=uom, qty_uos=qty_uos,
+            uos=uos, name=name, partner_id=partner_id, lang=lang,
+            update_tax=update_tax, date_order=date_order, packaging=packaging,
+            fiscal_position=fiscal_position, flag=flag)
+        if product:
+            p = self.env['product.product'].browse(product)
+            res['value']['performance'] = p.performance
+        return res

--- a/sale_order_line_performance/tests/__init__.py
+++ b/sale_order_line_performance/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_sale_order_line_performance

--- a/sale_order_line_performance/tests/test_sale_order_line_performance.py
+++ b/sale_order_line_performance/tests/test_sale_order_line_performance.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestSaleOrderLinePerformance(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleOrderLinePerformance, self).setUp()
+        self.sale_model = self.env['sale.order']
+        self.product = self.env.ref('product.product_product_consultant')
+        self.product.performance = 5.0
+        sale_vals = {
+            'partner_id': self.ref('base.res_partner_1'),
+            'partner_shipping_id': self.ref('base.res_partner_1'),
+            'partner_invoice_id': self.ref('base.res_partner_1'),
+            'pricelist_id': self.env.ref('product.list0').id}
+        sale_line_vals = {
+            'product_id': self.product.id,
+            'name': self.product.name,
+            'product_uos_qty': 7,
+            'product_uom': self.product.uom_id.id,
+            'price_unit': self.product.list_price}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+
+    def test_sale_order_line_performance(self):
+        line = self.sale_order.order_line[0]
+        res = line.product_id_change(
+            self.sale_order.pricelist_id.id, line.product_id.id,
+            qty=line.product_uom_qty, qty_uos=line. product_uos_qty,
+            name=line.name, partner_id=self.sale_order.partner_id.id,
+            update_tax=True, date_order=self.sale_order.date_order,
+            fiscal_position=self.sale_order.fiscal_position.id)
+        self.assertEqual(
+            self.product.performance, res['value'].get('performance', 0),
+            'Different performances')
+        self.assertEqual(
+            line.price_subtotal,
+            line.price_unit * line.performance * line.product_uom_qty,
+            'Error in sale orde line subtotal')

--- a/sale_order_line_performance/views/product_product_view.xml
+++ b/sale_order_line_performance/views/product_product_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="product_normal_form_view_inh_galaxiacustom" model="ir.ui.view">
+            <field name="name">product.normal.form.view.inh.galaxiacustom</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_normal_form_view"/>
+            <field name="arch" type="xml">
+                <field name="default_code" position="after">
+                    <field name="performance" widget="float_time"
+                           attrs="{'invisible': [('type', '!=', 'service')]}"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_line_performance/views/sale_order_view.xml
+++ b/sale_order_line_performance/views/sale_order_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="view_order_form_inh_galaxiacustom" model="ir.ui.view">
+            <field name="name">view.order.form.inh.galaxiacustom</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='order_line']//form//field[@name='address_allotment_id']" position="after">
+                    <field name="performance" widget="float_time" />
+                </xpath>
+                <xpath expr="//field[@name='order_line']//tree//field[@name='price_unit']" position="after">
+                    <field name="performance" widget="float_time" />
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
… order line, and in product.
Nuevo módulo para cubrir tarea de OdooMRP T3718 - DESA C2) A Rendimientos:

En el producto, se ha añadido el campo "performance": tiempo estimado para la realización de la tarea. Solo visible si el producto es de tipo "servicio".
Al seleccionar el producto en la línea de pedido de venta, se trae el rendimiento del producto a la línea de pedido.
El cálculo del subtotal del pedido de venta = quantity * performance * price unit