### PR TITLE
[ADD] procurement_service_project: New route "Generate procurement-ta…

### DIFF
--- a/procurement_service_project/README.rst
+++ b/procurement_service_project/README.rst
@@ -1,0 +1,26 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+===========================
+Procurement service project
+===========================
+
+* This module creates the new route "Generate procurement-task" for products.
+
+* When you are confirming a sales order that has a product of type "service",
+  and this product has the new route "Generate procurement-task", one
+  procurement for this service product is created.
+ 
+* Running this procurement, a task is automatically created. If you have
+  defined a project in sale order, this project will be assigned to the created
+  task.
+
+Credits
+=======
+
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/procurement_service_project/__init__.py
+++ b/procurement_service_project/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models

--- a/procurement_service_project/__openerp__.py
+++ b/procurement_service_project/__openerp__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Procurement Service Project",
+    'version': '8.0.1.1.0',
+    'license': "AGPL-3",
+    'author': "AvanzOSC",
+    'website': "http://www.avanzosc.es",
+    'contributors': [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es",
+    ],
+    "category": "Event Management",
+    "depends": [
+        'sale',
+        'project',
+        'procurement_service'
+    ],
+    "data": [
+        "data/procurement_service_project_data.xml",
+    ],
+    "installable": True,
+    "auto_install": True,
+}

--- a/procurement_service_project/data/procurement_service_project_data.xml
+++ b/procurement_service_project/data/procurement_service_project_data.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+        <!-- Create new route -->
+        <record id="route_serv_project" model='stock.location.route'>
+            <field name="name">Generate procurement-task</field>
+            <field name="sequence">20</field>
+        </record>
+    </data>
+</openerp>

--- a/procurement_service_project/i18n/es.po
+++ b/procurement_service_project/i18n/es.po
@@ -1,0 +1,57 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* procurement_service_project
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-01-22 08:57+0000\n"
+"PO-Revision-Date: 2016-01-22 09:59+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: procurement_service_project
+#: model:stock.location.route,name:procurement_service_project.route_serv_project
+msgid "Generate procurement-task"
+msgstr "Generar abastecimiento-tarea"
+
+#. module: procurement_service_project
+#: field:project.task,service_project_procurement:0
+msgid "Generated From Procurement"
+msgstr "Generada desde el abastecimiento"
+
+#. module: procurement_service_project
+#: field:project.task,service_project_sale_line:0
+msgid "Generated From Sale Line"
+msgstr "Generada desde la línea de venta"
+
+#. module: procurement_service_project
+#: field:procurement.order,service_project_task:0
+msgid "Generated task from procurement"
+msgstr "Tarea generada desde el abastecimiento"
+
+#. module: procurement_service_project
+#: model:ir.model,name:procurement_service_project.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+
+#. module: procurement_service_project
+#: field:sale.order,project:0
+msgid "Project"
+msgstr "Proyecto"
+
+#. module: procurement_service_project
+#: model:ir.model,name:procurement_service_project.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: procurement_service_project
+#: model:ir.model,name:procurement_service_project.model_project_task
+msgid "Task"
+msgstr "Tarea"

--- a/procurement_service_project/models/__init__.py
+++ b/procurement_service_project/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import sale_order
+from . import procurement_order
+from . import project_task

--- a/procurement_service_project/models/procurement_order.py
+++ b/procurement_service_project/models/procurement_order.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, fields, api
+
+
+class ProcurementOrder(models.Model):
+    _inherit = 'procurement.order'
+
+    service_project_task = fields.Many2one(
+        'project.task', string='Generated task from procurement')
+
+    @api.model
+    def _run(self, procurement):
+        task_obj = self.env['project.task']
+        route = procurement.product_id.route_ids.filtered(lambda r: r.id in [
+            self.env.ref('procurement_service_project.route_serv_project').id])
+        if procurement.product_id.type == 'service' and route:
+            task_obj._create_task_from_procurement_service_project(procurement)
+        return super(ProcurementOrder, self)._run(procurement)

--- a/procurement_service_project/models/project_task.py
+++ b/procurement_service_project/models/project_task.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, fields
+
+
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+
+    service_project_procurement = fields.Many2one(
+        'procurement.order', string='Generated From Procurement')
+    service_project_sale_line = fields.Many2one(
+        'sale.order.line', string='Generated From Sale Line')
+
+    def _create_task_from_procurement_service_project(self, procurement):
+        project_obj = self.env['project.project']
+        vals = self._moves_for_create_task_service_project(procurement)
+        if procurement.sale_line_id.order_id.project_id:
+            cond = [('analytic_account_id', '=',
+                     procurement.sale_line_id.order_id.project_id.id)]
+            project = project_obj.search(cond, limit=1)
+            if project:
+                vals['project_id'] = project.id
+        task = self.env['project.task'].create(vals)
+        procurement.service_project_task = task.id
+        return task
+
+    def _moves_for_create_task_service_project(self, procurement):
+        vals = {'name': '%s:%s' % (procurement.origin or '',
+                                   procurement.product_id.name),
+                'date_deadline': procurement.date_planned,
+                'planned_hours': procurement.product_qty,
+                'remaining_hours': procurement.product_qty,
+                'partner_id': procurement.sale_line_id.order_id.partner_id.id,
+                'user_id': procurement.product_id.product_manager.id,
+                'service_project_procurement': procurement.id,
+                'service_project_sale_line':  procurement.sale_line_id.id,
+                'description': procurement.name + '\n',
+                'company_id': procurement.company_id.id}
+        return vals

--- a/procurement_service_project/models/sale_order.py
+++ b/procurement_service_project/models/sale_order.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def action_button_confirm(self):
+        procurement_obj = self.env['procurement.order']
+        procurement_group_obj = self.env['procurement.group']
+        res = super(SaleOrder, self).action_button_confirm()
+        for line in self.order_line:
+            valid = self._validate_service_project_for_procurement(
+                line.product_id)
+            if valid:
+                if not self.procurement_group_id:
+                    vals = self._prepare_procurement_group(self)
+                    group = procurement_group_obj.create(vals)
+                    self.write({'procurement_group_id': group.id})
+                vals = self._prepare_order_line_procurement(
+                    self, line, group_id=self.procurement_group_id.id)
+                vals['name'] = self.name + ' - ' + line.product_id.name
+                procurement_obj.create(vals)
+        return res
+
+    def _validate_service_project_for_procurement(self, product):
+        routes = product.route_ids.filtered(lambda r: r.id in [
+            self.env.ref('procurement_service_project.route_serv_project').id])
+        return product.type == 'service' and routes

--- a/procurement_service_project/tests/__init__.py
+++ b/procurement_service_project/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_procurement_service_project

--- a/procurement_service_project/tests/test_procurement_service_project.py
+++ b/procurement_service_project/tests/test_procurement_service_project.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestProcurementServiceProject(common.TransactionCase):
+
+    def setUp(self):
+        super(TestProcurementServiceProject, self).setUp()
+        self.sale_model = self.env['sale.order']
+        self.procurement_model = self.env['procurement.order']
+        account_vals = {'name': 'account procurement service project'}
+        self.account = self.env['account.analytic.account'].create(
+            account_vals)
+        project_vals = {'name': 'project procurement service project',
+                        'analytic_account_id': self.account.id}
+        self.project = self.env['project.project'].create(project_vals)
+        service_product = self.env.ref('product.product_product_consultant')
+        service_product.route_ids = [
+            (6, 0,
+             [self.ref('procurement_service_project.route_serv_project')])]
+        sale_vals = {
+            'partner_id': self.ref('base.res_partner_1'),
+            'partner_shipping_id': self.ref('base.res_partner_1'),
+            'partner_invoice_id': self.ref('base.res_partner_1'),
+            'pricelist_id': self.env.ref('product.list0').id,
+            'project_id': self.account.id}
+        sale_line_vals = {
+            'product_id': service_product.id,
+            'name': service_product.name,
+            'product_uos_qty': 7,
+            'product_uom': service_product.uom_id.id,
+            'price_unit': service_product.list_price}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+
+    def test_procurement_service_project(self):
+        self.sale_order.action_button_confirm()
+        cond = [('sale_line_id', '=', self.sale_order.order_line[0].id)]
+        procurement = self.procurement_model.search(cond)
+        self.assertEqual(
+            len(procurement), 1,
+            'Procurement not generated for product service')
+        procurement.run()
+        self.assertEqual(
+            len(self.project.tasks), 1,
+            'Task not generated from procurement')


### PR DESCRIPTION
…sk" for products.

Nuevo módulo para cubrir parte de la tarea T3715 - DESA C2) Contrato(Automatización). Este nuevo módulo hace lo siguiente:
1.- Crea para productos la nueva ruta "Generate procurement-task"
2.- Cuando se confirma un pedido de venta que tiene un pedido de tipo "servicio", y este producto tiene la ruta "Generate procurement-task", se genera un abastecimiento para este producto de tipo servicio.
3.- Al ejecutar este abastecimiento, se creará una tarea automáticamente. Si se ha definido un proyecto en el pedido de venta, se asignará a la tarea creada.

@oihane, @anajuaristi , este es el módulo que hemos quitado de "odoomrp-wip"