### PR TITLE
[MOD] crm_claim_channel: translates added, menu for source and channel

### DIFF
--- a/crm_claim_channel/i18n/es.po
+++ b/crm_claim_channel/i18n/es.po
@@ -1,0 +1,56 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* crm_claim_channel
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-01-27 11:20+0000\n"
+"PO-Revision-Date: 2016-01-27 12:22+0100\n"
+"Last-Translator: Esther Martín <esthermartin@avanzosc.es>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: crm_claim_channel
+#: view:crm.claim:crm_claim_channel.crm_claim_close_view_form
+msgid "Channel info"
+msgstr "Información del canal"
+
+#. module: crm_claim_channel
+#: view:crm.tracking.medium:crm_claim_channel.crm_tracking_medium_view_tree
+#: view:crm.tracking.source:crm_claim_channel.crm_tracking_source_view_tree
+#: model:ir.ui.menu,name:crm_claim_channel.menu_crm_tracking_medium
+msgid "Channels"
+msgstr "Canales"
+
+#. module: crm_claim_channel
+#: model:ir.model,name:crm_claim_channel.model_crm_claim
+msgid "Claim"
+msgstr "Reclamación"
+
+#. module: crm_claim_channel
+#: view:crm.claim:crm_claim_channel.crm_claim_close_view_form
+msgid "Claim/Action Description"
+msgstr "Descripción de la reclamación/acción"
+
+#. module: crm_claim_channel
+#: field:crm.claim,input_channel:0
+msgid "Input channel"
+msgstr "Canal entrada"
+
+#. module: crm_claim_channel
+#: field:crm.claim,response_channel:0
+msgid "Response channel"
+msgstr "Canal respuesta"
+
+#. module: crm_claim_channel
+#: field:crm.claim,source_id:0
+#: model:ir.ui.menu,name:crm_claim_channel.menu_crm_tracking_source2
+msgid "Source"
+msgstr "Origen"
+

--- a/crm_claim_channel/views/crm_claim_view.xml
+++ b/crm_claim_channel/views/crm_claim_view.xml
@@ -6,14 +6,43 @@
             <field name="inherit_id" ref="crm_claim.crm_case_claims_form_view" />
             <field name="arch" type="xml">
                 <separator string="Claim/Action Description" position="before">
-                <separator string="Channel info" colspan="2"/>
-                <group>
-                    <field name="input_channel"/>
-                    <field name="response_channel"/>
-                    <field name="source_id"/>
-                </group>
+                    <separator string="Channel info" colspan="2"/>
+                    <group>
+                        <field name="input_channel"/>
+                        <field name="response_channel"/>
+                        <field name="source_id"/>
+                    </group>
                 </separator>
             </field>
         </record>
+
+        <record id="crm_tracking_medium_view_tree" model="ir.ui.view">
+            <field name="name">crm.tracking.medium.tree</field>
+            <field name="model">crm.tracking.medium</field>
+            <field name="inherit_id" ref="crm.crm_tracking_medium_view_tree" />
+            <field name="arch" type="xml">
+                <tree string="Channels" position="attributes">
+                    <attribute name="editable">top</attribute>
+                </tree>
+            </field>
+        </record>
+
+        <menuitem action="crm.crm_tracking_medium_action" id="menu_crm_tracking_medium"
+            parent="crm_claim.menu_config_claim" groups="base.group_no_one"/>
+
+        <record id="crm_tracking_source_view_tree" model="ir.ui.view">
+            <field name="name">crm.tracking.source.tree</field>
+            <field name="model">crm.tracking.source</field>
+            <field name="inherit_id" ref="crm.crm_tracking_source_view_tree"/>
+            <field name="arch" type="xml">
+                <tree string="Channels" position="attributes">
+                    <attribute name="editable">top</attribute>
+                </tree>
+            </field>
+        </record>
+
+        <delete id="crm.menu_crm_tracking_source" model="ir.ui.menu"/>
+        <menuitem action="crm.crm_tracking_source_action" id="menu_crm_tracking_source2"
+                  parent="crm_claim.menu_config_claim" groups="base.group_no_one"/>
     </data>
 </openerp>


### PR DESCRIPTION
Los campos están bien, pero no existe menú o al menos no lo hemos encontrado para poder gestionar los canales. Se pueden dar de alta y modificar directamente. 
Pero no se pueden borrar, ni tampoco hemos encontrado menú de mantenimiento. 
El campo  Origen sí que está en configuración de Iniciativas/oportunidades pero el canal no está.

Crearemos menú también para Origen, debajo de configuración/reclamaciones, en el mismo punto donde están las categorías y etapas de reclamación.