### PR TITLE
[FIX] sale_service_recurrence_configurator: Fix error in onchange tem…

### DIFF
--- a/sale_service_recurrence_configurator/models/sale.py
+++ b/sale_service_recurrence_configurator/models/sale.py
@@ -47,7 +47,8 @@ class SaleOrder(models.Model):
                 if len(template) > 1:
                     cond = [('quote_id', '=', template_id),
                             ('product_template', '!=', False),
-                            ('product_id', '=', False)]
+                            ('product_id', '=', False),
+                            ('name', '=', dic.get('name'))]
                     template = quote_obj.search(cond, limit=1)
                 line[2].update({
                     'product_template': template.product_template.id,


### PR DESCRIPTION
…plate_id sales order.

No se traía bien las líneas de plantilla de pedido de venta, en el onchage de "template_id", de pedidos de venta.

@oihane , @Daniel-CA , @agaldona , @esthermm .... ¿Le podéis echar un vistazo?.

Eskerrik asko.