### PR TITLE
[FIX] project_events_copy: Set as installing the module.

### DIFF
--- a/project_events_copy/__openerp__.py
+++ b/project_events_copy/__openerp__.py
@@ -14,11 +14,11 @@
     ],
     "category": "Project Management",
     "depends": [
-        "event_project",
+        "project_events",
     ],
     'data': [
         "wizard/copy_event_view.xml",
     ],
-    "installable": False,
+    "installable": True,
     "auto_install": False,
 }


### PR DESCRIPTION
Poner la antigüa dependencia que tenía el módulo, y ponerlo como instalable.

