### PR TITLE
[ADD] sale_order_create_event_with_hour: Include two new fields: Star…

### DIFF
--- a/sale_order_create_event_with_hour/README.rst
+++ b/sale_order_create_event_with_hour/README.rst
@@ -1,0 +1,20 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+=================================
+Sale order create event with hour
+=================================
+
+* Include two new fields: Start time and End time type "time" on the sale
+  contract. Take this times to the event dates. The start and end dates of the
+  wizards "Add Person To Session" and "" Delete Person From Event-Session ",
+  become fields of type" datetime ".
+
+Credits
+=======
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/sale_order_create_event_with_hour/__init__.py
+++ b/sale_order_create_event_with_hour/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models
+from . import wizard

--- a/sale_order_create_event_with_hour/__openerp__.py
+++ b/sale_order_create_event_with_hour/__openerp__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Sale Order Create Event With Hour",
+    'version': '8.0.1.1.0',
+    'license': "AGPL-3",
+    'author': "AvanzOSC",
+    'website': "http://www.avanzosc.es",
+    'contributors': [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es",
+    ],
+    "category": "Event Management",
+    "depends": [
+        'account_analytic_analysis',
+        'sale_order_create_event',
+    ],
+    "data": [
+        'wizard/wiz_event_append_assistant_view.xml',
+        'wizard/wiz_event_delete_assistant_view.xml',
+        'views/account_analytic_account_view.xml',
+    ],
+    "installable": True,
+}

--- a/sale_order_create_event_with_hour/i18n/es.po
+++ b/sale_order_create_event_with_hour/i18n/es.po
@@ -1,0 +1,51 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_order_create_event_with_hour
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-02-16 15:42+0000\n"
+"PO-Revision-Date: 2016-02-16 16:43+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: sale_order_create_event_with_hour
+#: model:ir.model,name:sale_order_create_event_with_hour.model_account_analytic_account
+msgid "Analytic Account"
+msgstr "Cuenta analítica"
+
+#. module: sale_order_create_event_with_hour
+#: field:account.analytic.account,end_time:0
+#: field:wiz.event.append.assistant,end_time:0
+#: field:wiz.event.delete.assistant,end_time:0
+msgid "End time"
+msgstr "Hora fin"
+
+#. module: sale_order_create_event_with_hour
+#: model:ir.model,name:sale_order_create_event_with_hour.model_event_registration
+msgid "Event Registration"
+msgstr "Registro evento"
+
+#. module: sale_order_create_event_with_hour
+#: model:ir.model,name:sale_order_create_event_with_hour.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: sale_order_create_event_with_hour
+#: field:account.analytic.account,start_time:0
+#: field:wiz.event.append.assistant,start_time:0
+#: field:wiz.event.delete.assistant,start_time:0
+msgid "Start time"
+msgstr "Hora inicio"
+
+#. module: sale_order_create_event_with_hour
+#: model:ir.model,name:sale_order_create_event_with_hour.model_project_task
+msgid "Task"
+msgstr "Tarea"

--- a/sale_order_create_event_with_hour/models/__init__.py
+++ b/sale_order_create_event_with_hour/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import account_analytic_account
+from . import sale_order
+from . import project_task
+from . import event_registration

--- a/sale_order_create_event_with_hour/models/account_analytic_account.py
+++ b/sale_order_create_event_with_hour/models/account_analytic_account.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, fields
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = 'account.analytic.account'
+
+    start_time = fields.Float(string='Start time')
+    end_time = fields.Float(string='End time')

--- a/sale_order_create_event_with_hour/models/event_registration.py
+++ b/sale_order_create_event_with_hour/models/event_registration.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+
+
+class EventRegistration(models.Model):
+
+    _inherit = 'event.registration'
+
+    def _prepare_wizard_registration_open_vals(self):
+        wiz_vals = super(EventRegistration,
+                         self)._prepare_wizard_registration_open_vals()
+        start_time = self._convert_times_to_float(self.event_id.date_begin)
+        end_time = self._convert_times_to_float(self.event_id.date_end)
+        wiz_vals.update({'start_time': start_time,
+                         'end_time': end_time})
+        return wiz_vals
+
+    def _prepare_date_start_for_track_condition(self, date):
+        new_date = self._convert_date_to_local_format(date).date()
+        start_time = self._convert_times_to_float(self.event_id.date_begin)
+        new_date = self._put_utc_format_date(
+            new_date, start_time).strftime('%Y-%m-%d %H:%M:%S')
+        return new_date
+
+    def _prepare_date_end_for_track_condition(self, date):
+        new_date = self._convert_date_to_local_format(date).date()
+        end_time = self._convert_times_to_float(self.event_id.date_end)
+        new_date = self._put_utc_format_date(
+            new_date, end_time).strftime('%Y-%m-%d %H:%M:%S')
+        return new_date
+
+    def _prepare_wizard_reg_cancel_vals(self):
+        wiz_vals = super(EventRegistration,
+                         self)._prepare_wizard_reg_cancel_vals()
+        start_time = self._convert_times_to_float(self.event_id.date_begin)
+        end_time = self._convert_times_to_float(self.event_id.date_end)
+        wiz_vals.update({'start_time': start_time,
+                         'end_time': end_time})
+        return wiz_vals
+
+    def _convert_times_to_float(self, date):
+        minutes = 0.0
+        seconds = 0.0
+        local_time = self._convert_date_to_local_format(
+            date).strftime("%H:%M:%S")
+        time = local_time.split(':')
+        hour = float(time[0])
+        if int(time[1]) > 0:
+            minutes = float(time[1]) / 60
+        if int(time[2]) > 0:
+            seconds = float(time[2]) / 360
+        return hour + minutes + seconds

--- a/sale_order_create_event_with_hour/models/project_task.py
+++ b/sale_order_create_event_with_hour/models/project_task.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+
+
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+
+    def _account_info_for_create_task_service_project(self, vals, procurement):
+        vals = super(
+            ProjectTask, self)._account_info_for_create_task_service_project(
+            vals, procurement)
+        if (procurement.sale_line_id.order_id.project_id.date_start and
+                procurement.sale_line_id.order_id.project_id.start_time):
+            date_start = self._convert_date_to_local_format(
+                procurement.sale_line_id.order_id.project_id.date_start).date()
+            time = procurement.sale_line_id.order_id.project_id.start_time
+            vals['date_start'] = self._put_utc_format_date(date_start, time)
+        if (procurement.sale_line_id.order_id.project_id.date and
+                procurement.sale_line_id.order_id.project_id.end_time):
+            date_end = self._convert_date_to_local_format(
+                procurement.sale_line_id.order_id.project_id.date).date()
+            time = procurement.sale_line_id.order_id.project_id.end_time
+            vals['date_end'] = self._put_utc_format_date(date_end, time)
+        return vals
+
+    def _prepare_session_data_from_task(self, event, num_session, date):
+        vals = super(ProjectTask, self)._prepare_session_data_from_task(
+            event, num_session, date)
+        time = self.service_project_sale_line.order_id.project_id.start_time
+        vals['date'] = self._put_utc_format_date(date, time)
+        return vals

--- a/sale_order_create_event_with_hour/models/sale_order.py
+++ b/sale_order_create_event_with_hour/models/sale_order.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _prepare_event_data(self, project):
+        res = super(SaleOrder, self)._prepare_event_data(project)
+        if self.project_id.date_start:
+            time = self.project_id.start_time or 0
+            utc_dt = self._put_utc_format_date(self.project_id.date_start,
+                                               time)
+            res['date_begin'] = utc_dt
+        if self.project_id.date:
+            time = self.project_id.end_time or 0
+            utc_dt = self._put_utc_format_date(self.project_id.date, time)
+            res['date_end'] = utc_dt
+        return res
+
+    def _prepare_session_data_from_sale_line(
+            self, event, num_session, line, date):
+        vals = super(SaleOrder, self)._prepare_session_data_from_sale_line(
+            event, num_session, line, date)
+        time = self.project_id.start_time or 0
+        vals['date'] = self._put_utc_format_date(date, time)
+        return vals

--- a/sale_order_create_event_with_hour/tests/__init__.py
+++ b/sale_order_create_event_with_hour/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_sale_order_create_event_with_hour

--- a/sale_order_create_event_with_hour/tests/test_sale_order_create_event_with_hour.py
+++ b/sale_order_create_event_with_hour/tests/test_sale_order_create_event_with_hour.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestSaleOrderCreateEventWithHour(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleOrderCreateEventWithHour, self).setUp()
+        self.move_line_model = self.env['account.move.line']
+        self.task_model = self.env['project.task']
+        self.sale_model = self.env['sale.order']
+        self.procurement_model = self.env['procurement.order']
+        self.event_model = self.env['event.event']
+        self.registration_model = self.env['event.registration']
+        self.wiz_append_model = self.env['wiz.event.append.assistant']
+        self.wiz_delete_model = self.env['wiz.event.delete.assistant']
+        account_vals = {'name': 'account procurement service project',
+                        'date_start': '2016-02-01',
+                        'date': '2016-02-28',
+                        'start_time': 5.0,
+                        'end_time': 10.0}
+        self.account = self.env['account.analytic.account'].create(
+            account_vals)
+        project_vals = {'name': 'project procurement service project',
+                        'analytic_account_id': self.account.id,
+                        'partners': [(6, 0, [self.ref('base.res_partner_1')])]}
+        self.project = self.env['project.project'].create(project_vals)
+        service_product = self.env.ref('product.product_product_consultant')
+        service_product.write({'performance': 5.0,
+                               'recurring_service': True})
+        service_product.performance = 5.0
+        service_product.route_ids = [
+            (6, 0,
+             [self.ref('procurement_service_project.route_serv_project')])]
+        sale_vals = {
+            'partner_id': self.ref('base.res_partner_1'),
+            'partner_shipping_id': self.ref('base.res_partner_1'),
+            'partner_invoice_id': self.ref('base.res_partner_1'),
+            'pricelist_id': self.env.ref('product.list0').id,
+            'project_id': self.account.id,
+            'project_by_task': 'yes'}
+        sale_line_vals = {
+            'product_id': service_product.id,
+            'name': service_product.name,
+            'product_uom_qty': 7,
+            'product_uos_qty': 7,
+            'product_uom': service_product.uom_id.id,
+            'price_unit': service_product.list_price,
+            'performance': 5.0,
+            'january': True,
+            'february': True,
+            'week4': True,
+            'week5': True,
+            'tuesday': True,
+            'thursday': True}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+
+    def test_sale_order_create_event_with_hour(self):
+        cond = [('product_id', '!=', False)]
+        move_line = self.move_line_model.search([], limit=1)
+        move_line.journal_id.type = 'sale'
+        move_line._prepare_analytic_line(move_line)
+        self.sale_order.action_button_confirm()
+        sale_line = self.sale_order.order_line[0]
+        cond = [('project_id', '=', self.project.id)]
+        event = self.event_model.search(cond, limit=1)
+        event.assign_partners()
+        registration_vals = {
+            'name': 'aaaaaaa',
+            'event_id': event.id,
+            'partner_id': self.ref('base.res_partner_1')}
+        registration = self.registration_model.create(registration_vals)
+        registration._prepare_wizard_registration_open_vals()
+        registration._prepare_date_start_for_track_condition(
+            '2016-05-21 17:30:00')
+        registration._prepare_date_end_for_track_condition(
+            '2016-07-21 19:00:00')
+        registration._prepare_wizard_reg_cancel_vals()
+        wiz_append_vals = {
+            'from_date': '2016-02-01',
+            'to_date': '2016-02-28',
+            'partner': self.ref('base.res_partner_2')}
+        wiz = self.wiz_append_model.create(wiz_append_vals)
+        wiz.with_context({'active_ids': [event.id]}).action_append()
+        wiz = self.wiz_delete_model.create(wiz_append_vals)
+        wiz.with_context(
+            {'active_ids': [event.id]}).action_nodelete_past_and_later()
+        cond = [('service_project_sale_line', '=', sale_line.id)]
+        task = self.task_model.search(cond, limit=1)
+        task.show_sessions_from_task()
+        self.assertNotEqual(
+            len(task.sessions), 0,
+            'Sessions no generated')

--- a/sale_order_create_event_with_hour/views/account_analytic_account_view.xml
+++ b/sale_order_create_event_with_hour/views/account_analytic_account_view.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_analytic_account_form_inh_with_hour" model="ir.ui.view">
+            <field name="name">view.analytic.account.form.inh.with.hour</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="analytic.view_account_analytic_account_form" />
+            <field name="arch" type="xml">
+                <field name="date_start" position="after">
+                    <field name="start_time" widget="float_time"/>
+                </field>
+            </field>
+        </record>
+        <record id="account_analytic_account_form_inh_with_hour" model="ir.ui.view">
+            <field name="name">account.analytic.account.form.inh.with_hour</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="account_analytic_analysis.account_analytic_account_form_form" />
+            <field name="arch" type="xml">
+                 <label for="quantity_max" position="before">
+                    <field name="end_time" widget="float_time"/>
+                 </label>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_create_event_with_hour/wizard/__init__.py
+++ b/sale_order_create_event_with_hour/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import wiz_event_append_assistant
+from . import wiz_event_delete_assistant

--- a/sale_order_create_event_with_hour/wizard/wiz_event_append_assistant.py
+++ b/sale_order_create_event_with_hour/wizard/wiz_event_append_assistant.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models
+
+
+class WizEventAppendAssistant(models.TransientModel):
+    _inherit = 'wiz.event.append.assistant'
+
+    start_time = fields.Float(string='Start time')
+    end_time = fields.Float(string='End time')
+
+    def _update_registration_start_date(self, registration):
+        from_date = self._convert_date_to_local_format(self.from_date).date()
+        registration.date_start = self._put_utc_format_date(
+            from_date, self.start_time)
+
+    def _update_registration_date_end(self, registration):
+        to_date = self._convert_date_to_local_format(self.to_date).date()
+        registration.date_end = self._put_utc_format_date(
+            to_date, self.end_time)
+
+    def _prepare_registration_data(self, event):
+        date_start = self._convert_date_to_local_format(self.from_date).date()
+        date_end = self._convert_date_to_local_format(self.to_date).date()
+        vals = {'event_id': event.id,
+                'partner_id': self.partner.id,
+                'state': 'open',
+                'date_start': self._put_utc_format_date(
+                    date_start, self.start_time),
+                'date_end': self._put_utc_format_date(
+                    date_end, self.end_time)}
+        return vals
+
+    def _calc_dates_for_search_track(self, from_date, to_date):
+        from_date = self._put_utc_format_date(
+            from_date, self.start_time).strftime('%Y-%m-%d %H:%M:%S')
+        to_date = self._put_utc_format_date(
+            to_date, self.end_time).strftime('%Y-%m-%d %H:%M:%S')
+        return from_date, to_date
+
+    def _prepare_track_search_condition(self, event):
+        cond = [('id', 'in', event.track_ids.ids),
+                '|', ('date', '=', False), '&',
+                ('date', '>=', self.from_date),
+                ('date', '<=', self.to_date)]
+        return cond

--- a/sale_order_create_event_with_hour/wizard/wiz_event_append_assistant_view.xml
+++ b/sale_order_create_event_with_hour/wizard/wiz_event_append_assistant_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="wiz_event_append_assistant_form_inh_with_hour">
+            <field name="name">wiz.event.append.assistant.form.inh.with.hour</field>
+            <field name="model">wiz.event.append.assistant</field>
+            <field name="inherit_id" ref="event_track_assistant.wiz_event_append_assistant_form" />
+            <field name="arch" type="xml">
+                <field name="from_date" position="after">
+                    <field name="start_time" widget="float_time" />
+                </field>
+                <field name="to_date" position="after">
+                    <field name="end_time" widget="float_time" />
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_create_event_with_hour/wizard/wiz_event_delete_assistant.py
+++ b/sale_order_create_event_with_hour/wizard/wiz_event_delete_assistant.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models
+
+
+class WizEventDeleteAssistant(models.TransientModel):
+    _inherit = 'wiz.event.delete.assistant'
+
+    start_time = fields.Float(string='Start time')
+    end_time = fields.Float(string='End time')
+
+    def _prepare_track_condition_from_date(self, sessions):
+        from_date = self._put_utc_format_date(
+            self.from_date, self.start_time).strftime('%Y-%m-%d %H:%M:%S')
+        cond = [('id', 'in', sessions.ids),
+                ('date', '<', from_date)]
+        return cond
+
+    def _prepare_track_condition_to_date(self, sessions):
+        to_date = self._put_utc_format_date(
+            self.to_date, self.end_time).strftime('%Y-%m-%d %H:%M:%S')
+        cond = [('id', 'in', sessions.ids),
+                ('date', '>', to_date)]
+        return cond
+
+    def _prepare_track_search_condition_for_delete(self, sessions):
+        from_date = self._put_utc_format_date(
+            self.from_date, self.start_time).strftime('%Y-%m-%d %H:%M:%S')
+        to_date = self._put_utc_format_date(
+            self.to_date, self.end_time).strftime('%Y-%m-%d %H:%M:%S')
+        cond = [('id', 'in', sessions.ids),
+                '|', ('date', '=', False), '&',
+                ('date', '>=', from_date),
+                ('date', '<=', to_date)]
+        return cond

--- a/sale_order_create_event_with_hour/wizard/wiz_event_delete_assistant_view.xml
+++ b/sale_order_create_event_with_hour/wizard/wiz_event_delete_assistant_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="wiz_event_delete_assistant_form_inh_with_hour">
+            <field name="name">wiz.event.delete.assistant.form.inh.with.hour</field>
+            <field name="model">wiz.event.delete.assistant</field>
+            <field name="inherit_id" ref="event_track_assistant.wiz_event_delete_assistant_form" />
+            <field name="arch" type="xml">
+                <field name="from_date" position="after">
+                    <field name="start_time" widget="float_time" />
+                </field>
+                <field name="to_date" position="after">
+                    <field name="end_time" widget="float_time" />
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
…t time and End time type "time" on the sale contract.

Nuevo módulo solicitado por @anajuaristi , para cubrir la tarea T3744 - Horario. Incluir dos campos nuevos: Hora inicio y Hora fin tipo "hora" en el contrato y en el evento. Si estos 2 campos están informados, arrastrar al "evento" desde el contrato cuando se crea. Añadir los 2 campos a las sesiones y al "wizard de asignación", de tal forma que al asignar un trabajador a un evento, se asigne también el horario.

@oihane , @agaldona , @esthermm , @Daniel-CA .... ¿Le podéis echar un vistazo a la programación?. Eskerrik asko.

NOTA: Falla "coveralls", este fallo no se quitará hasta que no se haga el PR https://github.com/avanzosc/odoo-addons/pull/99, del módulo "sale_order_create_event".
