### PR TITLE
[ADD] purchase_order_line_with_sale_account: The contract of the sale…

### DIFF
--- a/purchase_order_line_with_sale_account/README.rst
+++ b/purchase_order_line_with_sale_account/README.rst
@@ -1,0 +1,21 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+======================================
+Purchase order line with sale acccount
+======================================
+
+* With this module if a contract is defined in the sale order, and when the
+  purchase order is generated from the procurement order, and the "purchase
+  procured grouping" field of product category, has the value "No line
+  grouping", the contract of the sale order will be, to the line of the
+  purchase order.
+
+Credits
+=======
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/purchase_order_line_with_sale_account/__init__.py
+++ b/purchase_order_line_with_sale_account/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models

--- a/purchase_order_line_with_sale_account/__openerp__.py
+++ b/purchase_order_line_with_sale_account/__openerp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Purchase Order Line With Sale Account",
+    'version': '8.0.1.1.0',
+    'license': "AGPL-3",
+    'author': "AvanzOSC",
+    'website': "http://www.avanzosc.es",
+    'contributors': [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es",
+    ],
+    "category": "Procurements",
+    "depends": [
+        'sale',
+        'procurement_purchase_no_grouping',
+    ],
+    "data": [],
+    "installable": True,
+}

--- a/purchase_order_line_with_sale_account/i18n/es.po
+++ b/purchase_order_line_with_sale_account/i18n/es.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* purchase_order_line_with_sale_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-02-15 14:36+0000\n"
+"PO-Revision-Date: 2016-02-15 14:36+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: purchase_order_line_with_sale_account
+#: model:ir.model,name:purchase_order_line_with_sale_account.model_procurement_order
+msgid "Procurement"
+msgstr "Abastecimiento"
+

--- a/purchase_order_line_with_sale_account/models/__init__.py
+++ b/purchase_order_line_with_sale_account/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import procurement_order

--- a/purchase_order_line_with_sale_account/models/procurement_order.py
+++ b/purchase_order_line_with_sale_account/models/procurement_order.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, api
+
+
+class ProcurementOrder(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.multi
+    def write(self, vals):
+        res = super(ProcurementOrder, self).write(vals)
+        if 'purchase_line_id' in vals:
+            for proc in self:
+                group = proc.product_id.categ_id.procured_purchase_grouping
+                if group == 'line':
+                    proc._update_purchase_line_account_from_sale_account()
+        return res
+
+    def _update_purchase_line_account_from_sale_account(self):
+        cond = [('id', '<', self.id),
+                ('product_uom', '=', self.product_uom.id),
+                ('product_uos_qty', '=', self.product_uos_qty),
+                ('product_qty', '=', self.product_qty),
+                ('product_uos', '=', self.product_uos.id),
+                ('state', '=', 'running'),
+                ('product_id', '=', self.product_id.id),
+                ('group_id', '=', self.group_id.id),
+                ('sale_line_id', '!=', False)]
+        proc = self.search(cond, limit=1)
+        if proc.sale_line_id.order_id.project_id:
+            self.purchase_line_id.account_analytic_id = (
+                proc.sale_line_id.order_id.project_id.id)

--- a/purchase_order_line_with_sale_account/tests/__init__.py
+++ b/purchase_order_line_with_sale_account/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_purchase_order_line_with_sale_account

--- a/purchase_order_line_with_sale_account/tests/test_purchase_order_line_with_sale_account.py
+++ b/purchase_order_line_with_sale_account/tests/test_purchase_order_line_with_sale_account.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestPurchaseOrderLineWithSaleAccount(common.TransactionCase):
+
+    def setUp(self):
+        super(TestPurchaseOrderLineWithSaleAccount, self).setUp()
+        self.procurement_model = self.env['procurement.order']
+        self.sale_model = self.env['sale.order']
+        product = self.env.ref('product.product_product_36')
+        product.categ_id.procured_purchase_grouping = 'line'
+        product.route_ids = [(6, 0,
+                              [self.ref('purchase.route_warehouse0_buy'),
+                               self.ref('stock.route_warehouse0_mto')])]
+        account_vals = {'name': 'purchase_order_line_with_sale_account',
+                        'date_start': '2016-01-15',
+                        'date': '2016-02-28'}
+        self.account = self.env['account.analytic.account'].create(
+            account_vals)
+        sale_vals = {
+            'partner_id': self.ref('base.res_partner_1'),
+            'partner_shipping_id': self.ref('base.res_partner_1'),
+            'partner_invoice_id': self.ref('base.res_partner_1'),
+            'pricelist_id': self.env.ref('product.list0').id,
+            'project_id': self.account.id}
+        sale_line_vals = {
+            'product_id': product.id,
+            'name': product.name,
+            'product_uom_qty': 7,
+            'product_uos_qty': 7,
+            'product_uom': product.uom_id.id,
+            'price_unit': product.list_price}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+
+    def test_sale_order_create_event(self):
+        self.sale_order.action_button_confirm()
+        cond = [('sale_line_id', '=', self.sale_order.order_line[0].id)]
+        proc = self.procurement_model.search(cond, limit=1)
+        cond = [('id', '>', proc.id),
+                ('product_uom', '=', proc.product_uom.id),
+                ('product_uos_qty', '=', proc.product_uos_qty),
+                ('product_qty', '=', proc.product_qty),
+                ('product_uos', '=', proc.product_uos.id),
+                ('product_id', '=', proc.product_id.id),
+                ('group_id', '=', proc.group_id.id)]
+        proc = self.procurement_model.search(cond, limit=1)
+        if proc.state == 'confirmed':
+            proc.run()
+        self.assertNotEqual(
+            proc.purchase_line_id.account_analytic_id, False,
+            'Purchase line without analytic account')


### PR DESCRIPTION
… order will be, to the line of the purchase order.

Nuevo módulo soliticado por @anajuaristi , para cubrir la tarea T3746 - Arrastrar cuenta analítica de pedido de venta a línea de pedido de compra.
Al confirmar el pedido de venta, arrastrar la cuenta analítica del pedido de venta a la línea de pedido de compra.

Este módulo deberá tener dependencia con procurement_no_group. Hay que hacer un módulo de extensión de este, para que al crear el pedido de compra (sin agrupar líneas) arrastre la cuenta analítica del pedido de venta a cada una de las líneas del pedido de compra. 

Con este módulo si se define un contrato en el pedido de venta, y cuando se genera el pedido de compra desde el abastecimiento, el campo "Procured purchase grouping" de la categoría del producto, tiene el valor "No line grouping", se llevará el contrato del pedido de venta, a la línea del pedido de compra.

@oihane , @agaldona , @esthermm , @Daniel-CA .... ¿le podéis echar un vistazo a la programación?.
Eskerrika asko.