### PR TITLE
[ADD] sale_order_create_event_with_hour: Include two new fields: Star…

### DIFF
--- a/sale_order_create_event/README.rst
+++ b/sale_order_create_event/README.rst
@@ -11,7 +11,9 @@ Sale order create event
   "Generate procurement-task", and is one recursive product, necessary sessions
   are automatically generated. These sessions will be associated with the
   corresponding task.
-* You can recalculate the sessions from project task form
+* You can recalculate the sessions from project task form.
+* To register partners in events, the partner should not be my company, not a
+  customer, and not a supplier.
 
 Credits
 =======

--- a/sale_order_create_event/i18n/es.po
+++ b/sale_order_create_event/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-02-24 11:25+0000\n"
-"PO-Revision-Date: 2016-02-24 12:27+0100\n"
+"POT-Creation-Date: 2016-02-25 08:44+0000\n"
+"PO-Revision-Date: 2016-02-25 09:45+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -25,6 +25,16 @@ msgstr "Añadir empresa a tareas"
 #: field:sale.order,project_by_task:0
 msgid "Create project by task"
 msgstr "Crear proyecto por tarea"
+
+#. module: sale_order_create_event
+#: view:res.partner:sale_order_create_event.view_res_partner_filter_inh_sale_create_event
+msgid "Employees"
+msgstr "Empleados"
+
+#. module: sale_order_create_event
+#: view:res.partner:sale_order_create_event.view_res_partner_filter_inh_sale_create_event
+msgid "Employees Partners"
+msgstr "Empleados que estan grabados como no clientes/proveedores"
 
 #. module: sale_order_create_event
 #: model:ir.model,name:sale_order_create_event.model_event_registration
@@ -64,6 +74,7 @@ msgstr "Proyecto"
 
 #. module: sale_order_create_event
 #: code:addons/sale_order_create_event/models/sale_order.py:31
+#: code:addons/sale_order_create_event/models/sale_order.py:33
 #, python-format
 msgid "Project/contract without project"
 msgstr "Proyecto/contrato sin proyecto"
@@ -85,8 +96,8 @@ msgstr "Pedido de venta"
 
 #. module: sale_order_create_event
 #: code:addons/sale_order_create_event/models/project.py:217
-#: code:addons/sale_order_create_event/models/sale_order.py:110
 #: code:addons/sale_order_create_event/models/sale_order.py:123
+#: code:addons/sale_order_create_event/models/sale_order.py:125
 #, python-format
 msgid "Session %s for %s"
 msgstr "Sesión %s para %s"
@@ -115,24 +126,33 @@ msgid "Tasks"
 msgstr "Tareas"
 
 #. module: sale_order_create_event
+#: code:addons/sale_order_create_event/models/sale_order.py:21
+#, python-format
+msgid "User without time zone"
+msgstr "Usuario sin zona horaria definida"
+
+#. module: sale_order_create_event
 #: selection:sale.order,project_by_task:0
 msgid "Yes"
 msgstr "Si"
 
 #. module: sale_order_create_event
 #: code:addons/sale_order_create_event/models/sale_order.py:26
+#: code:addons/sale_order_create_event/models/sale_order.py:28
 #, python-format
 msgid "You must enter the end date of the project/contract"
 msgstr "Debe de introducir la fecha fin del proyecto/contracto"
 
 #. module: sale_order_create_event
 #: code:addons/sale_order_create_event/models/sale_order.py:21
+#: code:addons/sale_order_create_event/models/sale_order.py:23
 #, python-format
 msgid "You must enter the project/contract"
 msgstr "Debe de introducir el proyecto/contracto"
 
 #. module: sale_order_create_event
 #: code:addons/sale_order_create_event/models/sale_order.py:23
+#: code:addons/sale_order_create_event/models/sale_order.py:25
 #, python-format
 msgid "You must enter the start date of the project/contract"
 msgstr "Debe de introducir la fecha de inicio del proyecto/contrato"
@@ -141,3 +161,4 @@ msgstr "Debe de introducir la fecha de inicio del proyecto/contrato"
 #: view:wiz.event.append.assistant:sale_order_create_event.wiz_event_append_assistant_form_inh_createevent
 msgid "tasks"
 msgstr "tareas"
+

--- a/sale_order_create_event/models/sale_order.py
+++ b/sale_order_create_event/models/sale_order.py
@@ -17,6 +17,8 @@ class SaleOrder(models.Model):
     @api.multi
     def action_button_confirm(self):
         project_obj = self.env['project.project']
+        if not self.env.user.tz:
+            raise exceptions.Warning(_('User without time zone'))
         if not self.project_id:
             raise exceptions.Warning(_('You must enter the project/contract'))
         if not self.project_id.date_start:

--- a/sale_order_create_event/views/event_event_view.xml
+++ b/sale_order_create_event/views/event_event_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_event_form_partner_inh_sale_create_event" model="ir.ui.view">
+            <field name="name">view.event.form.partner.inh.sale.create.event</field>
+            <field name="model">event.event</field>
+            <field name="inherit_id" ref="partner_event.view_event_form_partner" />
+            <field name="arch" type="xml">
+                <field name="partner_id"  position="attributes">
+                    <attribute name="context">{'default_customer': False,'default_supplier': False,'default_is_company': False}</attribute>
+                    <attribute name="domain">[('customer','=',False),('supplier','=',False),('is_company','=',False)]</attribute>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_create_event/views/res_partner_view.xml
+++ b/sale_order_create_event/views/res_partner_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_res_partner_filter_inh_sale_create_event" model="ir.ui.view">
+            <field name="name">view.res.partner.filter.inh.sale.create.event</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base.view_res_partner_filter" />
+            <field name="arch" type="xml">
+                <filter name="type_company" position="after">
+                   <separator/>
+                   <filter string="Employees" name="employees" help="Employees Partners"
+                        domain="[('customer','=',False),('supplier','=',False),('is_company','=',False)]"/>
+                </filter>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_create_event/views/sale_order_view.xml
+++ b/sale_order_create_event/views/sale_order_view.xml
@@ -9,6 +9,9 @@
                 <field name="project_id" position="after">
                     <field name="project_by_task" required="1" />
                 </field>
+                <field name="project_id" position="attributes">
+                    <attribute name="context">{'partner_id':partner_invoice_id, 'manager_id': user_id, 'default_use_tasks':True,'default_pricelist_id':pricelist_id, 'default_name':name, 'default_type': 'contract'}</attribute>
+                </field>
             </field>
         </record>
     </data>

--- a/sale_order_create_event_hour/README.rst
+++ b/sale_order_create_event_hour/README.rst
@@ -1,0 +1,20 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+============================
+Sale order create event hour
+============================
+
+* Include two new fields: Start time and End time type "time" on the sale
+  contract. Take this times to the event dates. The start and end dates of the
+  wizards "Add Person To Session" and "" Delete Person From Event-Session ",
+  become fields of type" datetime ".
+
+Credits
+=======
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/sale_order_create_event_hour/__init__.py
+++ b/sale_order_create_event_hour/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models
+from . import wizard

--- a/sale_order_create_event_hour/__openerp__.py
+++ b/sale_order_create_event_hour/__openerp__.py
@@ -2,7 +2,7 @@
 # (c) 2016 Alfredo de la Fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
-    "name": "Sale Order Create Event",
+    "name": "Sale Order Create Event Hour",
     'version': '8.0.1.1.0',
     'license': "AGPL-3",
     'author': "AvanzOSC",
@@ -13,17 +13,13 @@
     ],
     "category": "Event Management",
     "depends": [
-        'analytic',
-        'event_project_follower',
-        'event_track_assistant',
-        'project_task_generated_with_product_performance',
+        'account_analytic_analysis',
+        'sale_order_create_event',
     ],
     "data": [
         'wizard/wiz_event_append_assistant_view.xml',
-        'views/sale_order_view.xml',
-        'views/project_task_view.xml',
-        'views/event_event_view.xml',
-        'views/res_partner_view.xml'
+        'wizard/wiz_event_delete_assistant_view.xml',
+        'views/account_analytic_account_view.xml',
     ],
     "installable": True,
 }

--- a/sale_order_create_event_hour/i18n/es.po
+++ b/sale_order_create_event_hour/i18n/es.po
@@ -1,0 +1,51 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_create_event_hour
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-02-25 09:23+0000\n"
+"PO-Revision-Date: 2016-02-25 09:23+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_order_create_event_hour
+#: model:ir.model,name:sale_order_create_event_hour.model_account_analytic_account
+msgid "Analytic Account"
+msgstr "Cuenta analítica"
+
+#. module: sale_order_create_event_hour
+#: field:account.analytic.account,end_time:0
+#: field:wiz.event.append.assistant,end_time:0
+#: field:wiz.event.delete.assistant,end_time:0
+msgid "End time"
+msgstr "Hora fin"
+
+#. module: sale_order_create_event_hour
+#: model:ir.model,name:sale_order_create_event_hour.model_event_registration
+msgid "Event Registration"
+msgstr "Registro evento"
+
+#. module: sale_order_create_event_hour
+#: model:ir.model,name:sale_order_create_event_hour.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: sale_order_create_event_hour
+#: field:account.analytic.account,start_time:0
+#: field:wiz.event.append.assistant,start_time:0
+#: field:wiz.event.delete.assistant,start_time:0
+msgid "Start time"
+msgstr "Hora inicio"
+
+#. module: sale_order_create_event_hour
+#: model:ir.model,name:sale_order_create_event_hour.model_project_task
+msgid "Task"
+msgstr "Tarea"
+

--- a/sale_order_create_event_hour/models/__init__.py
+++ b/sale_order_create_event_hour/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import account_analytic_account
+from . import sale_order
+from . import project_task
+from . import event_registration

--- a/sale_order_create_event_hour/models/account_analytic_account.py
+++ b/sale_order_create_event_hour/models/account_analytic_account.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, fields
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = 'account.analytic.account'
+
+    start_time = fields.Float(string='Start time', default=0.0)
+    end_time = fields.Float(string='End time', default=0.0)

--- a/sale_order_create_event_hour/models/event_registration.py
+++ b/sale_order_create_event_hour/models/event_registration.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+
+
+class EventRegistration(models.Model):
+
+    _inherit = 'event.registration'
+
+    def _prepare_wizard_registration_open_vals(self):
+        wiz_vals = super(EventRegistration,
+                         self)._prepare_wizard_registration_open_vals()
+        start_time = self._convert_times_to_float(self.event_id.date_begin)
+        end_time = self._convert_times_to_float(self.event_id.date_end)
+        wiz_vals.update({'start_time': start_time,
+                         'end_time': end_time})
+        return wiz_vals
+
+    def _prepare_date_start_for_track_condition(self, date):
+        new_date = self._convert_date_to_local_format(date).date()
+        start_time = self._convert_times_to_float(self.event_id.date_begin)
+        new_date = self._put_utc_format_date(
+            new_date, start_time).strftime('%Y-%m-%d %H:%M:%S')
+        return new_date
+
+    def _prepare_date_end_for_track_condition(self, date):
+        new_date = self._convert_date_to_local_format(date).date()
+        end_time = self._convert_times_to_float(self.event_id.date_end)
+        new_date = self._put_utc_format_date(
+            new_date, end_time).strftime('%Y-%m-%d %H:%M:%S')
+        return new_date
+
+    def _prepare_wizard_reg_cancel_vals(self):
+        wiz_vals = super(EventRegistration,
+                         self)._prepare_wizard_reg_cancel_vals()
+        start_time = self._convert_times_to_float(self.event_id.date_begin)
+        end_time = self._convert_times_to_float(self.event_id.date_end)
+        wiz_vals.update({'start_time': start_time,
+                         'end_time': end_time})
+        return wiz_vals
+
+    def _convert_times_to_float(self, date):
+        minutes = 0.0
+        seconds = 0.0
+        local_time = self._convert_date_to_local_format(
+            date).strftime("%H:%M:%S")
+        time = local_time.split(':')
+        hour = float(time[0])
+        if int(time[1]) > 0:
+            minutes = float(time[1]) / 60
+        if int(time[2]) > 0:
+            seconds = float(time[2]) / 360
+        return hour + minutes + seconds

--- a/sale_order_create_event_hour/models/project_task.py
+++ b/sale_order_create_event_hour/models/project_task.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+
+
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+
+    def _account_info_for_create_task_service_project(self, vals, procurement):
+        vals = super(
+            ProjectTask, self)._account_info_for_create_task_service_project(
+            vals, procurement)
+        if (procurement.sale_line_id.order_id.project_id.date_start and
+                procurement.sale_line_id.order_id.project_id.start_time):
+            date_start = self._convert_date_to_local_format(
+                procurement.sale_line_id.order_id.project_id.date_start).date()
+            time = procurement.sale_line_id.order_id.project_id.start_time
+            vals['date_start'] = self._put_utc_format_date(date_start, time)
+        if (procurement.sale_line_id.order_id.project_id.date and
+                procurement.sale_line_id.order_id.project_id.end_time):
+            date_end = self._convert_date_to_local_format(
+                procurement.sale_line_id.order_id.project_id.date).date()
+            time = procurement.sale_line_id.order_id.project_id.end_time
+            vals['date_end'] = self._put_utc_format_date(date_end, time)
+        return vals
+
+    def _prepare_session_data_from_task(self, event, num_session, date):
+        vals = super(ProjectTask, self)._prepare_session_data_from_task(
+            event, num_session, date)
+        time = self.service_project_sale_line.order_id.project_id.start_time
+        vals['date'] = self._put_utc_format_date(date, time)
+        return vals

--- a/sale_order_create_event_hour/models/sale_order.py
+++ b/sale_order_create_event_hour/models/sale_order.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _prepare_event_data(self, project):
+        res = super(SaleOrder, self)._prepare_event_data(project)
+        if self.project_id.date_start:
+            time = self.project_id.start_time or 0
+            utc_dt = self._put_utc_format_date(self.project_id.date_start,
+                                               time)
+            res['date_begin'] = utc_dt
+        if self.project_id.date:
+            time = self.project_id.end_time or 0
+            utc_dt = self._put_utc_format_date(self.project_id.date, time)
+            res['date_end'] = utc_dt
+        return res
+
+    def _prepare_session_data_from_sale_line(
+            self, event, num_session, line, date):
+        vals = super(SaleOrder, self)._prepare_session_data_from_sale_line(
+            event, num_session, line, date)
+        time = self.project_id.start_time or 0
+        vals['date'] = self._put_utc_format_date(date, time)
+        return vals

--- a/sale_order_create_event_hour/tests/__init__.py
+++ b/sale_order_create_event_hour/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_sale_order_create_event_hour

--- a/sale_order_create_event_hour/tests/test_sale_order_create_event_hour.py
+++ b/sale_order_create_event_hour/tests/test_sale_order_create_event_hour.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestSaleOrderCreateEventHour(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleOrderCreateEventHour, self).setUp()
+        self.task_model = self.env['project.task']
+        self.sale_model = self.env['sale.order']
+        self.account_model = self.env['account.analytic.account']
+        self.project_model = self.env['project.project']
+        self.event_model = self.env['event.event']
+        self.task_model = self.env['project.task']
+        self.procurement_model = self.env['procurement.order']
+        self.wiz_add_model = self.env['wiz.event.append.assistant']
+        self.wiz_del_model = self.env['wiz.event.delete.assistant']
+        account_vals = {'name': 'account procurement service project',
+                        'date_start': '2016-01-15',
+                        'start_time': 5.0,
+                        'end_time': 10.0,
+                        'date': '2016-02-28'}
+        self.account = self.account_model.create(account_vals)
+        project_vals = {'name': 'project procurement service project',
+                        'analytic_account_id': self.account.id}
+        self.project = self.project_model.create(project_vals)
+        service_product = self.env.ref('product.product_product_consultant')
+        service_product.write({'performance': 5.0,
+                               'recurring_service': True})
+        service_product.performance = 5.0
+        service_product.route_ids = [
+            (6, 0,
+             [self.ref('procurement_service_project.route_serv_project')])]
+        sale_vals = {
+            'name': 'sale order 1',
+            'partner_id': self.ref('base.res_partner_1'),
+            'partner_shipping_id': self.ref('base.res_partner_1'),
+            'partner_invoice_id': self.ref('base.res_partner_1'),
+            'pricelist_id': self.env.ref('product.list0').id,
+            'project_id': self.account.id,
+            'project_by_task': 'no'}
+        sale_line_vals = {
+            'product_id': service_product.id,
+            'name': service_product.name,
+            'product_uom_qty': 7,
+            'product_uos_qty': 7,
+            'product_uom': service_product.uom_id.id,
+            'price_unit': service_product.list_price,
+            'performance': 5.0,
+            'january': True,
+            'february': True,
+            'week4': True,
+            'week5': True,
+            'tuesday': True,
+            'thursday': True}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+        account_vals = {'name': 'account procurement service project 2',
+                        'date_start': '2016-01-15',
+                        'date': '2016-02-28'}
+        self.account2 = self.account_model.create(account_vals)
+        project_vals = {'name': 'project procurement service project 2',
+                        'analytic_account_id': self.account2.id}
+        self.project2 = self.project_model.create(project_vals)
+        sale_vals.update({'name': 'sale order 2',
+                          'project_id': self.account2.id,
+                          'project_by_task': 'yes'})
+        self.sale_order2 = self.sale_model.create(sale_vals)
+
+    def test_sale_order_create_event_hour(self):
+        self.sale_order.action_button_confirm()
+        self.project.tasks[0]._calc_num_sessions()
+        self.project.tasks[0].show_sessions_from_task()
+        self.project.tasks[0].button_recalculate_sessions()
+        cond = [('project_id', '=', self.project.id)]
+        event = self.event_model.search(cond, limit=1)
+        wiz_vals = {'from_date': '2016-01-15',
+                    'to_date': '2016-02-28',
+                    'partner': self.env.ref('base.res_partner_26').id}
+        wiz = self.wiz_add_model.with_context(
+            {'active_ids': [event.id]}).create(wiz_vals)
+        wiz.with_context({'active_ids': [event.id]}).action_append()
+        wiz._update_registration_start_date(event.registration_ids[0])
+        wiz._update_registration_date_end(event.registration_ids[0])
+        wiz_vals = {'from_date': '2016-01-15',
+                    'to_date': '2016-02-28',
+                    'partner': self.env.ref('base.res_partner_26').id}
+        wiz = self.wiz_del_model.create(wiz_vals)
+        wiz.with_context(
+            {'active_ids': [event.id]}).onchange_information()
+        wiz.with_context(
+            {'active_ids': [event.id]}).action_nodelete_past_and_later()
+        wiz.with_context(
+            {'active_ids':
+             [event.id]})._delete_registrations_between_dates(
+            self.project.tasks[0].sessions)
+        wiz.with_context(
+            {'active_ids': [event.id]}).action_delete_past_and_later()
+        event.registration_ids[0].with_context(
+            {'event_id': event.id}).registration_open()
+        event.registration_ids[0].button_reg_cancel()
+        self.assertNotEqual(
+            len(self.project.tasks[0].sessions), 0,
+            'Sessions no generated')
+
+    def test_sale_order_create_event_hour_project_by_task(self):
+        self.sale_order2.action_button_confirm()
+        cond = [('parent_id', '=', self.account2.id)]
+        account = self.account_model.search(cond, limit=1)
+        cond = [('analytic_account_id', '=', account.id)]
+        project = self.project_model.search(cond, limit=1)
+        cond = [('project_id', '=', project.id)]
+        task = self.task_model.search(cond, limit=1)
+        task._calc_num_sessions()
+        task.show_sessions_from_task()
+        task.button_recalculate_sessions()
+        self.assertNotEqual(
+            len(task.sessions), 0,
+            'Sessions no generated 2')

--- a/sale_order_create_event_hour/views/account_analytic_account_view.xml
+++ b/sale_order_create_event_hour/views/account_analytic_account_view.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_analytic_account_form_inh_hour" model="ir.ui.view">
+            <field name="name">view.analytic.account.form.inh.hour</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="analytic.view_account_analytic_account_form" />
+            <field name="arch" type="xml">
+                <field name="date_start" position="after">
+                    <field name="start_time" widget="float_time"/>
+                </field>
+            </field>
+        </record>
+        <record id="account_analytic_account_form_inh_with_hour" model="ir.ui.view">
+            <field name="name">account.analytic.account.form.inh.with_hour</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="account_analytic_analysis.account_analytic_account_form_form" />
+            <field name="arch" type="xml">
+                 <label for="quantity_max" position="before">
+                    <field name="end_time" widget="float_time"/>
+                 </label>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_create_event_hour/wizard/__init__.py
+++ b/sale_order_create_event_hour/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import wiz_event_append_assistant
+from . import wiz_event_delete_assistant

--- a/sale_order_create_event_hour/wizard/wiz_event_append_assistant.py
+++ b/sale_order_create_event_hour/wizard/wiz_event_append_assistant.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models
+
+
+class WizEventAppendAssistant(models.TransientModel):
+    _inherit = 'wiz.event.append.assistant'
+
+    start_time = fields.Float(string='Start time', default=0.0)
+    end_time = fields.Float(string='End time', default=0.0)
+
+    def _update_registration_start_date(self, registration):
+        super(WizEventAppendAssistant, self)._update_registration_start_date(
+            registration)
+        from_date = self._convert_date_to_local_format(self.from_date).date()
+        registration.date_start = self._put_utc_format_date(
+            from_date, self.start_time)
+
+    def _update_registration_date_end(self, registration):
+        super(WizEventAppendAssistant, self)._update_registration_date_end(
+            registration)
+        to_date = self._convert_date_to_local_format(self.to_date).date()
+        registration.date_end = self._put_utc_format_date(
+            to_date, self.end_time)
+
+    def _prepare_registration_data(self, event):
+        date_start = self._convert_date_to_local_format(self.from_date).date()
+        date_end = self._convert_date_to_local_format(self.to_date).date()
+        vals = {'event_id': event.id,
+                'partner_id': self.partner.id,
+                'state': 'open',
+                'date_start': self._put_utc_format_date(
+                    date_start, self.start_time),
+                'date_end': self._put_utc_format_date(
+                    date_end, self.end_time)}
+        return vals
+
+    def _calc_dates_for_search_track(self, from_date, to_date):
+        from_date = self._put_utc_format_date(
+            from_date, self.start_time).strftime('%Y-%m-%d %H:%M:%S')
+        to_date = self._put_utc_format_date(
+            to_date, self.end_time).strftime('%Y-%m-%d %H:%M:%S')
+        return from_date, to_date
+
+    def _prepare_track_search_condition(self, event):
+        cond = [('id', 'in', event.track_ids.ids),
+                '|', ('date', '=', False), '&',
+                ('date', '>=', self.from_date),
+                ('date', '<=', self.to_date)]
+        return cond

--- a/sale_order_create_event_hour/wizard/wiz_event_append_assistant_view.xml
+++ b/sale_order_create_event_hour/wizard/wiz_event_append_assistant_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="wiz_event_append_assistant_form_inh_with_hour">
+            <field name="name">wiz.event.append.assistant.form.inh.with.hour</field>
+            <field name="model">wiz.event.append.assistant</field>
+            <field name="inherit_id" ref="event_track_assistant.wiz_event_append_assistant_form" />
+            <field name="arch" type="xml">
+                <field name="from_date" position="after">
+                    <field name="start_time" widget="float_time" />
+                </field>
+                <field name="to_date" position="after">
+                    <field name="end_time" widget="float_time" />
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_create_event_hour/wizard/wiz_event_delete_assistant.py
+++ b/sale_order_create_event_hour/wizard/wiz_event_delete_assistant.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models
+
+
+class WizEventDeleteAssistant(models.TransientModel):
+    _inherit = 'wiz.event.delete.assistant'
+
+    start_time = fields.Float(string='Start time', default=0.0)
+    end_time = fields.Float(string='End time', default=0.0)
+
+    def _prepare_track_condition_from_date(self, sessions):
+        from_date = self._put_utc_format_date(
+            self.from_date, self.start_time).strftime('%Y-%m-%d %H:%M:%S')
+        cond = [('id', 'in', sessions.ids),
+                ('date', '<', from_date)]
+        return cond
+
+    def _prepare_track_condition_to_date(self, sessions):
+        to_date = self._put_utc_format_date(
+            self.to_date, self.end_time).strftime('%Y-%m-%d %H:%M:%S')
+        cond = [('id', 'in', sessions.ids),
+                ('date', '>', to_date)]
+        return cond
+
+    def _prepare_track_search_condition_for_delete(self, sessions):
+        from_date = self._put_utc_format_date(
+            self.from_date, self.start_time).strftime('%Y-%m-%d %H:%M:%S')
+        to_date = self._put_utc_format_date(
+            self.to_date, self.end_time).strftime('%Y-%m-%d %H:%M:%S')
+        cond = [('id', 'in', sessions.ids),
+                '|', ('date', '=', False), '&',
+                ('date', '>=', from_date),
+                ('date', '<=', to_date)]
+        return cond

--- a/sale_order_create_event_hour/wizard/wiz_event_delete_assistant_view.xml
+++ b/sale_order_create_event_hour/wizard/wiz_event_delete_assistant_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="wiz_event_delete_assistant_form_inh_with_hour">
+            <field name="name">wiz.event.delete.assistant.form.inh.with.hour</field>
+            <field name="model">wiz.event.delete.assistant</field>
+            <field name="inherit_id" ref="event_track_assistant.wiz_event_delete_assistant_form" />
+            <field name="arch" type="xml">
+                <field name="from_date" position="after">
+                    <field name="start_time" widget="float_time" />
+                </field>
+                <field name="to_date" position="after">
+                    <field name="end_time" widget="float_time" />
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
…t time and End time type "time" on the sale contract.
Nuevo módulo solicitado por @anajuaristi , para cubrir la tarea T3744 - Horario. Incluir dos campos nuevos: Hora inicio y Hora fin tipo "hora" en el contrato y en el evento. Si estos 2 campos están informados, arrastrar al "evento" desde el contrato cuando se crea. Añadir los 2 campos a las sesiones y al "wizard de asignación", de tal forma que al asignar un trabajador a un evento, se asigne también el horario.