### PR TITLE
[IMP] procurement_service_project: catch sales order line description…

### DIFF
--- a/procurement_service_project/models/project_task.py
+++ b/procurement_service_project/models/project_task.py
@@ -33,7 +33,7 @@ class ProjectTask(models.Model):
 
     def _moves_for_create_task_service_project(self, procurement):
         vals = {'name': '%s:%s' % (procurement.origin or '',
-                                   procurement.product_id.name),
+                                   procurement.sale_line_id.name),
                 'date_deadline': procurement.date_planned,
                 'planned_hours': procurement.product_qty,
                 'remaining_hours': procurement.product_qty,


### PR DESCRIPTION
…, no description product.

Módulo modificado para que a la hora de crear la descripción de la tarea, en vez de coger la descripción del producto, coger la descripción de la línea del pedido de venta.