### PR TITLE
[ADD] sale_order_puchase_split_info: Purchase split info in sale order.

### DIFF
--- a/sale_order_purchase_split_info/README.rst
+++ b/sale_order_purchase_split_info/README.rst
@@ -1,0 +1,22 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+==============================
+Sale order purchase split info
+==============================
+
+* With this module the information of the wizard to split a purchase order, it
+  is stored in the sales order.
+
+* If the purchase order to divide, It is related to a purchase order divided,
+  wizard information will be charged with the purchase order information
+  previously divided.
+
+Credits
+=======
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/sale_order_purchase_split_info/__init__.py
+++ b/sale_order_purchase_split_info/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import wizard
+from . import models

--- a/sale_order_purchase_split_info/__openerp__.py
+++ b/sale_order_purchase_split_info/__openerp__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Sale Order Purchase Split Info",
+    'version': '8.0.1.1.0',
+    'license': "AGPL-3",
+    'author': "AvanzOSC",
+    'website': "http://www.avanzosc.es",
+    'contributors': [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es",
+    ],
+    "category": "Purchase Management",
+    "depends": [
+        'sale_stock',
+        'purchase_order_split',
+    ],
+    "data": [
+        "wizard/wiz_purchase_order_split_view.xml",
+        "views/sale_order_view.xml",
+    ],
+    "installable": True,
+}

--- a/sale_order_purchase_split_info/i18n/es.po
+++ b/sale_order_purchase_split_info/i18n/es.po
@@ -1,0 +1,82 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_order_purchase_split_info
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-11 09:16+0000\n"
+"PO-Revision-Date: 2016-04-11 11:21+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: sale_order_purchase_split_info
+#: model:ir.model,name:sale_order_purchase_split_info.model_wiz_purchase_order_split
+msgid "\"Wizard to split purchase order"
+msgstr "\"Wizard para dividir el pedido de compra"
+
+#. module: sale_order_purchase_split_info
+#: help:sale.order,purchase_from_date:0
+msgid "Expected date on which the first purchase order begins"
+msgstr "Fecha prevista en que se inicia la orden primera compra"
+
+#. module: sale_order_purchase_split_info
+#: help:sale.order,purchase_each_month:0
+msgid "Months interval to generate each purchase order"
+msgstr "Intervalo de meses para generar cada orden de compra"
+
+#. module: sale_order_purchase_split_info
+#: field:wiz.purchase.order.split,only_read:0
+msgid "Only read"
+msgstr "Solo lectura"
+
+#. module: sale_order_purchase_split_info
+#: view:sale.order:sale_order_purchase_split_info.view_order_form_inh_purchase_split_info
+msgid "Other Information"
+msgstr "Otra información"
+
+#. module: sale_order_purchase_split_info
+#: help:sale.order,purchase_parts:0
+msgid "Purchase order number to split the purchase order"
+msgstr "Número de pedidos de compra en el que dividir el pedido de compra"
+
+#. module: sale_order_purchase_split_info
+#: field:sale.order,purchase_each_month:0
+msgid "Purchase split each how many month"
+msgstr "Intervalo de meses para generar cada pedido de compra"
+
+#. module: sale_order_purchase_split_info
+#: field:sale.order,purchase_from_date:0
+msgid "Purchase split from date"
+msgstr "Divisiónn compra fecha desde"
+
+#. module: sale_order_purchase_split_info
+#: field:sale.order,purchase_parts:0
+msgid "Purchase split how many parts"
+msgstr "División compra en cuantas partes"
+
+#. module: sale_order_purchase_split_info
+#: view:sale.order:sale_order_purchase_split_info.view_order_form_inh_purchase_split_info
+msgid "Purchase split info"
+msgstr "Información división de compras"
+
+#. module: sale_order_purchase_split_info
+#: model:ir.model,name:sale_order_purchase_split_info.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: sale_order_purchase_split_info
+#: field:sale.order,split_purchases:0
+msgid "Split purchases"
+msgstr "Compras divididas"
+
+#. module: sale_order_purchase_split_info
+#: view:wiz.purchase.order.split:sale_order_purchase_split_info.wiz_purchase_order_split_form_inh_sale
+msgid "{'readonly':[('only_read','=',True)]}"
+msgstr "{'readonly':[('only_read','=',True)]}"

--- a/sale_order_purchase_split_info/models/__init__.py
+++ b/sale_order_purchase_split_info/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import sale_order

--- a/sale_order_purchase_split_info/models/sale_order.py
+++ b/sale_order_purchase_split_info/models/sale_order.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, fields
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    split_purchases = fields.Many2many(
+        'purchase.order', string='Split purchases')
+    purchase_parts = fields.Integer(
+        string='Purchase split how many parts',
+        help='Purchase order number to split the purchase order')
+    purchase_from_date = fields.Date(
+        string='Purchase split from date',
+        help='Expected date on which the first purchase order begins')
+    purchase_each_month = fields.Integer(
+        string='Purchase split each how many month',
+        help='Months interval to generate each purchase order')

--- a/sale_order_purchase_split_info/tests/__init__.py
+++ b/sale_order_purchase_split_info/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_sale_order_purchase_split_info

--- a/sale_order_purchase_split_info/tests/test_sale_order_purchase_split_info.py
+++ b/sale_order_purchase_split_info/tests/test_sale_order_purchase_split_info.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestSaleOrderPurchaseSplitInfo(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleOrderPurchaseSplitInfo, self).setUp()
+        self.sale_model = self.env['sale.order']
+        self.purchase_model = self.env['purchase.order']
+        self.procurement_model = self.env['procurement.order']
+        self.wiz_split_model = self.env['wiz.purchase.order.split']
+        orderpoint_obj = self.env['stock.warehouse.orderpoint']
+        product = self.env.ref('product.product_product_24')
+        product.route_ids = [
+            (6, 0,
+             [self.ref('stock.route_warehouse0_mto'),
+              self.ref('purchase.route_warehouse0_buy')])]
+        orderpoint_vals = {
+            'name': 'Alfredo probe',
+            'product_id': product.id,
+            'warehouse_id': self.ref('stock.warehouse0'),
+            'location_id': self.env.ref('stock.warehouse0').lot_stock_id.id,
+            'product_min_qty': 1,
+            'product_max_qty': 1,
+            'qty_multiple': 1.000,
+            'active': True}
+        orderpoint_obj.create(orderpoint_vals)
+        sale_vals = {
+            'partner_id': self.ref('base.res_partner_1'),
+            'partner_shipping_id': self.ref('base.res_partner_1'),
+            'partner_invoice_id': self.ref('base.res_partner_1'),
+            'pricelist_id': self.env.ref('product.list0').id}
+        sale_line_vals = {
+            'product_id': product.id,
+            'name': product.name,
+            'product_uos_qty': 12,
+            'product_uom': product.uom_id.id,
+            'price_unit': product.list_price}
+        sale_vals['order_line'] = [(0, 0, sale_line_vals)]
+        self.sale_order = self.sale_model.create(sale_vals)
+
+    def test_sale_order_purchase_split_info(self):
+        self.sale_order.action_button_confirm()
+        cond = [('sale_line_id', '=', self.sale_order.order_line[0].id)]
+        proc = self.procurement_model.search(cond, limit=1)
+        cond = [('id', '>', proc.id),
+                ('product_uom', '=', proc.product_uom.id),
+                ('product_uos_qty', '=', proc.product_uos_qty),
+                ('product_qty', '=', proc.product_qty),
+                ('product_uos', '=', proc.product_uos.id),
+                ('product_id', '=', proc.product_id.id),
+                ('group_id', '=', proc.group_id.id)]
+        proc = self.procurement_model.search(cond, limit=1)
+        if proc.state == 'confirmed':
+            proc.run()
+        self.assertNotEqual(
+            proc.purchase_id, False, 'Procurement without purchase')
+        wiz_vals = {'parts': 3,
+                    'from_date': '2016-03-30',
+                    'each_month': 2}
+        wiz = self.wiz_split_model.create(wiz_vals)
+        wiz.with_context(
+            {'active_ids':
+             [proc.purchase_id.id]}).action_split_purchase_order()
+        dat = ['each_month', 'only_read', 'from_date', 'parts']
+        wiz.with_context(
+            {'active_ids': [proc.purchase_id.id]}).default_get(dat)
+        self.assertEqual(
+            len(proc.purchase_id), 1, 'Purchases no generated')
+        wiz.with_context(
+            {'active_ids':
+             [proc.purchase_id.id]}).action_split_purchase_order()

--- a/sale_order_purchase_split_info/views/sale_order_view.xml
+++ b/sale_order_purchase_split_info/views/sale_order_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_order_form_inh_purchase_split_info" model="ir.ui.view">
+            <field name="name">view.order.form.inh.purchase.split.info</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form" />
+            <field name="arch" type="xml">
+                <page string="Other Information" position="after">
+                    <page string="Purchase split info">
+                       <group colspan="4" col="6">
+                           <field name="purchase_parts" colspan="2" readonly="1"/>
+                           <field name="purchase_from_date" colspan="2" readonly="1"/>
+                           <field name="purchase_each_month" colspan="2" readonly="1"/>
+                           <field name="split_purchases" colspan="6" nolabel="1" />
+                       </group>
+                    </page>
+                </page>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_purchase_split_info/wizard/__init__.py
+++ b/sale_order_purchase_split_info/wizard/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import wiz_purchase_order_split

--- a/sale_order_purchase_split_info/wizard/wiz_purchase_order_split.py
+++ b/sale_order_purchase_split_info/wizard/wiz_purchase_order_split.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models, api
+
+
+class WizPurchaseOrderSplit(models.TransientModel):
+    _inherit = 'wiz.purchase.order.split'
+
+    only_read = fields.Boolean(
+        string='Only read', default=False)
+
+    @api.model
+    def default_get(self, fields):
+        res = super(WizPurchaseOrderSplit, self).default_get(fields)
+        pur_obj = self.env['purchase.order']
+        proc_obj = self.env['procurement.order']
+        for purchase in pur_obj.browse(self.env.context.get('active_ids')):
+            for line in purchase.order_line:
+                sproc = False
+                cond = [('purchase_line_id', '=', line.id)]
+                proc = proc_obj.search(cond, limit=1)
+                if proc:
+                    sproc = self._search_sale_procurement(proc, line)
+                if sproc and sproc.sale_line_id.order_id.purchase_parts:
+                    sale = sproc.sale_line_id.order_id
+                    res.update({'parts': sale.purchase_parts,
+                                'from_date': sale.purchase_from_date,
+                                'each_month': sale.purchase_each_month,
+                                'only_read': True})
+                    break
+            if res.get('from_date', False):
+                break
+        return res
+
+    @api.multi
+    def action_split_purchase_order(self):
+        self.ensure_one()
+        res = super(WizPurchaseOrderSplit, self).action_split_purchase_order()
+        pur_obj = self.env['purchase.order']
+        proc_obj = self.env['procurement.order']
+        for purchase in pur_obj.browse(self.env.context.get('active_ids')):
+            for line in purchase.order_line:
+                sproc = False
+                cond = [('purchase_line_id', '=', line.id)]
+                proc = proc_obj.search(cond, limit=1)
+                if proc:
+                    sproc = self._search_sale_procurement(proc, line)
+                if sproc and sproc.sale_line_id.order_id:
+                    sale = sproc.sale_line_id.order_id
+                    sale.write({'purchase_parts': self.parts,
+                                'purchase_from_date': self.from_date,
+                                'purchase_each_month': self.each_month})
+                    if purchase.id not in sale.split_purchases.ids:
+                        sale.split_purchases = [(4, purchase.id)]
+        return res
+
+    def _search_sale_procurement(self, proc, line):
+        proc_obj = self.env['procurement.order']
+        sale_proc = self.env['procurement.order']
+        cond = [('id', '<', proc.id),
+                ('group_id', '=', proc.group_id.id),
+                ('product_id', '=', proc.product_id.id),
+                ('product_uos_qty', '=', proc.product_uos_qty),
+                ('product_qty', '=', proc.product_qty),
+                ('purchase_line_id', '=', False),
+                ('sale_line_id', '!=', False)]
+        sale_proc = proc_obj.search(cond, limit=1)
+        return sale_proc

--- a/sale_order_purchase_split_info/wizard/wiz_purchase_order_split_view.xml
+++ b/sale_order_purchase_split_info/wizard/wiz_purchase_order_split_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="wiz_purchase_order_split_form_inh_sale">
+            <field name="name">wiz.purchase.order.split.form.sale</field>
+            <field name="model">wiz.purchase.order.split</field>
+            <field name="inherit_id" ref="purchase_order_split.wiz_purchase_order_split_form" />
+            <field name="arch" type="xml">
+                <field name="each_month" position="after">
+                    <field name="only_read" />
+                </field>
+                <field name="parts" position="attributes">
+                    <attribute name="attrs">{'readonly':[('only_read','=',True)]}</attribute>
+                </field>
+                <field name="from_date" position="attributes">
+                    <attribute name="attrs">{'readonly':[('only_read','=',True)]}</attribute>
+                </field>
+                <field name="each_month" position="attributes">
+                    <attribute name="attrs">{'readonly':[('only_read','=',True)]}</attribute>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Nuevo módulo para mostrar en los pedidos de venta, la información del wizard cuando se ha dividido un pedido de compra.