### PR TITLE
[ADD] New module: lost object

### DIFF
--- a/lost_object/README.rst
+++ b/lost_object/README.rst
@@ -1,0 +1,18 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===========
+Lost Object
+===========
+
+* New menu item for manage lost objects.
+
+
+Credits
+=======
+
+
+Contributors
+------------
+* Esther Martín <esthermartin@avanzosc.es>

--- a/lost_object/README.rst
+++ b/lost_object/README.rst
@@ -8,6 +8,14 @@ Lost Object
 
 * New menu item for manage lost objects.
 
+* "Get Object" creates an stock move, from Virtual Locations/Lost objects to a
+  physical location. Also creates a lot which is connected to the created quant.
+
+* "Move Object" creates an stock move for a lot which is in a physical location
+  to another physical location.
+
+* "Give Object" creates an stock move, from lot which is in a physical location
+  to a Virtual Location/Customer.
 
 Credits
 =======

--- a/lost_object/__init__.py
+++ b/lost_object/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import wizard

--- a/lost_object/__openerp__.py
+++ b/lost_object/__openerp__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# © 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Lost Object",
+    "version": "8.0.1.0.0",
+    "category": "Custom Module",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Esther Martín <esthermartin@avanzosc.es>",
+    ],
+    "depends": [
+        "crm_claim",
+        "stock",
+    ],
+    "data": [
+        "data/sequence.xml",
+        "data/pesa_data.xml",
+        "wizard/get_object_view.xml",
+        "wizard/give_object_view.xml",
+        "wizard/move_object_view.xml",
+        "views/lost_object_view.xml",
+    ],
+    "installable": True,
+}

--- a/lost_object/data/pesa_data.xml
+++ b/lost_object/data/pesa_data.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <!-- Stock location -->
+        <record id="stock_location_lost" model="stock.location">
+            <field name="name">Lost object</field>
+            <field name="location_id" ref="stock.stock_location_locations_virtual"/>
+            <field name="usage">transit</field>
+            <field name="company_id"></field>
+        </record>
+
+        <record id="stock_location_virtual_customer" model="stock.location">
+            <field name="name">Customer</field>
+            <field name="location_id" ref="stock.stock_location_locations_virtual"/>
+            <field name="usage">customer</field>
+            <field name="company_id"></field>
+        </record>
+
+        <!--Product product -->
+        <record id="product_lost_object" model="product.product">
+            <field name="name">Objeto Perdido</field>
+            <field name="categ_id" ref="product.product_category_all"/>
+            <field name="type">product</field>
+            <field name="description">Objeto Perdido genérico</field>
+        </record>
+    </data>
+</openerp>

--- a/lost_object/data/pesa_data.xml
+++ b/lost_object/data/pesa_data.xml
@@ -18,10 +18,10 @@
 
         <!--Product product -->
         <record id="product_lost_object" model="product.product">
-            <field name="name">Objeto Perdido</field>
+            <field name="name">Lost object</field>
             <field name="categ_id" ref="product.product_category_all"/>
             <field name="type">product</field>
-            <field name="description">Objeto Perdido genérico</field>
+            <field name="description">Generic Lost Object</field>
         </record>
     </data>
 </openerp>

--- a/lost_object/data/sequence.xml
+++ b/lost_object/data/sequence.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data noupdate="1">
+        <record id="lost_object_code" model="ir.sequence.type">
+            <field name="name">Lost Object</field>
+            <field name="code">lost.object</field>
+        </record>
+        <record id="lost_object" model="ir.sequence">
+            <field name="name">Lost Object</field>
+            <field name="code">lost.object</field>
+            <field name="padding">5</field>
+        </record>
+    </data>
+</openerp>

--- a/lost_object/i18n/es.po
+++ b/lost_object/i18n/es.po
@@ -1,0 +1,148 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* lost_object
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-15 10:24+0000\n"
+"PO-Revision-Date: 2016-04-15 12:26+0100\n"
+"Last-Translator: Esther Martín <esthermartin@avanzosc.es>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: lost_object
+#: view:get.object.wiz:lost_object.get_object_wiz_view_form
+#: view:give.object.wiz:lost_object.give_object_wiz_view_form
+#: view:move.object.wiz:lost_object.move_object_wiz_view_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: lost_object
+#: view:get.object.wiz:lost_object.get_object_wiz_view_form
+#: view:give.object.wiz:lost_object.give_object_wiz_view_form
+#: view:move.object.wiz:lost_object.move_object_wiz_view_form
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: lost_object
+#: field:get.object.wiz,create_uid:0 field:give.object.wiz,create_uid:0
+#: field:move.object.wiz,create_uid:0
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: lost_object
+#: field:get.object.wiz,create_date:0 field:give.object.wiz,create_date:0
+#: field:move.object.wiz,create_date:0
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: lost_object
+#: model:stock.location,name:lost_object.stock_location_virtual_customer
+msgid "Customer"
+msgstr "Cliente"
+
+#. module: lost_object
+#: field:get.object.wiz,description:0
+msgid "Description"
+msgstr "Descripción"
+
+#. module: lost_object
+#: model:product.template,description:lost_object.product_lost_object_product_template
+msgid "Generic Lost Object"
+msgstr "Objeto Perdido Genérico"
+
+#. module: lost_object
+#: view:get.object.wiz:lost_object.get_object_wiz_view_form
+msgid "Get Object"
+msgstr "Recoger objeto"
+
+#. module: lost_object
+#: model:ir.actions.act_window,name:lost_object.get_object_action
+#: model:ir.ui.menu,name:lost_object.menu_get_object
+msgid "Get object"
+msgstr "Recoger objeto"
+
+#. module: lost_object
+#: view:give.object.wiz:lost_object.give_object_wiz_view_form
+msgid "Give Object"
+msgstr "Entragar objeto"
+
+#. module: lost_object
+#: model:ir.actions.act_window,name:lost_object.give_object_action
+#: model:ir.ui.menu,name:lost_object.menu_give_object
+msgid "Give object"
+msgstr "Entragar objeto"
+
+#. module: lost_object
+#: field:get.object.wiz,id:0 field:give.object.wiz,id:0
+#: field:move.object.wiz,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: lost_object
+#: field:get.object.wiz,write_uid:0 field:give.object.wiz,write_uid:0
+#: field:move.object.wiz,write_uid:0
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: lost_object
+#: field:get.object.wiz,write_date:0 field:give.object.wiz,write_date:0
+#: field:move.object.wiz,write_date:0
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: lost_object
+#: field:get.object.wiz,location_id:0 field:give.object.wiz,location_id:0
+#: field:move.object.wiz,location_id:0
+msgid "Location id"
+msgstr "Location id"
+
+#. module: lost_object
+#: model:ir.ui.menu,name:lost_object.menu_lost_objects
+msgid "Lost Objects"
+msgstr "Objets perdidos"
+
+#. module: lost_object
+#: model:product.template,name:lost_object.product_lost_object_product_template
+#: model:stock.location,name:lost_object.stock_location_lost
+msgid "Lost object"
+msgstr "Objeto perdido"
+
+#. module: lost_object
+#: field:give.object.wiz,lot_id:0 field:move.object.wiz,lot_id:0
+msgid "Lot"
+msgstr "Lote"
+
+#. module: lost_object
+#: view:move.object.wiz:lost_object.move_object_wiz_view_form
+msgid "Move Object"
+msgstr "Mover objeto"
+
+#. module: lost_object
+#: model:ir.actions.act_window,name:lost_object.move_object_action
+#: model:ir.ui.menu,name:lost_object.menu_move_object
+msgid "Move object"
+msgstr "Mover objeto"
+
+#. module: lost_object
+#: field:get.object.wiz,product_id:0
+msgid "Product"
+msgstr "Producto"
+
+#. module: lost_object
+#: field:get.object.wiz,sequence:0
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: lost_object
+#: view:get.object.wiz:lost_object.get_object_wiz_view_form
+#: view:give.object.wiz:lost_object.give_object_wiz_view_form
+#: view:move.object.wiz:lost_object.move_object_wiz_view_form
+msgid "or"
+msgstr "o"

--- a/lost_object/models/__init__.py
+++ b/lost_object/models/__init__.py
@@ -2,5 +2,4 @@
 # © 2015 Esther Martín - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from . import models
-from . import wizard
+from . import stock_production_lot

--- a/lost_object/models/stock_production_lot.py
+++ b/lost_object/models/stock_production_lot.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+
+from openerp import api, models
+
+
+class StockProductionLot(models.Model):
+    _inherit = 'stock.production.lot'
+
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        if args is None:
+            args = []
+        if not name == '':
+            args += ['|', ('ref', operator, name)]
+        results = super(StockProductionLot,
+                        self).name_search(name, args, operator, limit)
+        return results

--- a/lost_object/tests/__init__.py
+++ b/lost_object/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import test_lost_object

--- a/lost_object/tests/test_lost_object.py
+++ b/lost_object/tests/test_lost_object.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# © 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import openerp.tests.common as common
+
+
+class TestLostObject(common.TransactionCase):
+
+    def setUp(self):
+        super(TestLostObject, self).setUp()
+        self.ir_sequence_model = self.env['ir.sequence']
+        self.lost_object_sequence = self.browse_ref('lost_object.lost_object')
+        self.get_model = self.env['get.object.wiz']
+        self.give_model = self.env['give.object.wiz']
+        self.move_model = self.env['move.object.wiz']
+
+    def test_get_object(self):
+        sequence = self._get_next_code()
+        get_wiz = self.get_model.create({
+            'description': 'Blue jacket',
+            'location_id': self.ref('stock.stock_location_14')
+            })
+        product = self.env.ref('lost_object.product_lost_object')
+        self.assertEqual(product, get_wiz.product_id)
+        self.assertEqual(sequence, get_wiz.sequence)
+        get_wiz.confirm_get_object_lost()
+        quant = self.env['stock.quant'].search([
+            ('lot_id', '=', sequence)])
+        self.assertEqual(quant.location_id, get_wiz.location_id)
+        get_move_wiz = self.move_model.create({
+            'lot_id': quant.lot_id.id,
+            'location_id': self.ref('stock.stock_location_3')
+            })
+        get_move_wiz.confirm_move_object()
+        self.assertEqual(quant.location_id, get_move_wiz.location_id)
+        get_give_wiz = self.give_model.create({
+            'lot_id': quant.lot_id.id,
+            })
+        self.assertEqual(
+            get_give_wiz.location_id.id,
+            self.ref('lost_object.stock_location_virtual_customer'))
+        get_give_wiz.confirm_give_object()
+
+    def _get_next_code(self):
+        d = self.ir_sequence_model._interpolation_dict()
+        prefix = self.ir_sequence_model._interpolate(
+            self.lost_object_sequence.prefix, d)
+        suffix = self.ir_sequence_model._interpolate(
+            self.lost_object_sequence.suffix, d)
+        name = (prefix + ('%%0%sd' % self.lost_object_sequence.padding %
+                          self.lost_object_sequence.number_next_actual) +
+                suffix)
+        return name

--- a/lost_object/tests/test_lost_object.py
+++ b/lost_object/tests/test_lost_object.py
@@ -52,3 +52,15 @@ class TestLostObject(common.TransactionCase):
                           self.lost_object_sequence.number_next_actual) +
                 suffix)
         return name
+
+    def test_name_search(self):
+        sequence = self._get_next_code()
+        get_wiz = self.get_model.create({
+            'description': 'Mobile',
+            'location_id': self.ref('stock.stock_location_14')
+            })
+        get_wiz.confirm_get_object_lost()
+        lot = self.env['stock.production.lot'].search(
+            [('name', '=', sequence)])
+        res = lot.name_search('Mobile')
+        self.assertEqual([x[1] for x in res][0], sequence)

--- a/lost_object/views/lost_object_view.xml
+++ b/lost_object/views/lost_object_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <menuitem name="Lost Objects" id="menu_lost_objects" parent="base.menu_base_partner"
+            sequence="3" />
+        <menuitem name="Get object" id="menu_get_object" parent="menu_lost_objects" action="get_object_action"
+            />
+        <menuitem name="Move object" id="menu_move_object" parent="menu_lost_objects" action="move_object_action"
+            />
+        <menuitem name="Give object" id="menu_give_object" parent="menu_lost_objects" action="give_object_action"
+            />
+    </data>
+</openerp>

--- a/lost_object/wizard/__init__.py
+++ b/lost_object/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import lost_object

--- a/lost_object/wizard/get_object_view.xml
+++ b/lost_object/wizard/get_object_view.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        
+        <record id="get_object_wiz_view_form" model="ir.ui.view">
+            <field name="name">get.object.wiz.form</field>
+            <field name="model">get.object.wiz</field>
+            <field name="arch" type="xml">
+                <form string="Get Object">
+                    <group>
+                        <field name="sequence" readonly="True"/>
+                        <field name="product_id" required="True"/>
+                        <field name="description" required="True"/>
+                        <field name="location_id" required="True"/>
+                    </group>
+                    <footer>
+                        <button string="Confirm" name="confirm_get_object_lost"
+                                type="object" class="oe_highlight" />
+                        or
+                        <button string="Cancel" class="oe_link"
+                                special="cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="get_object_action" model="ir.actions.act_window">
+            <field name="name">Get object</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">get.object.wiz</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="get_object_wiz_view_form" />
+            <field name="target">new</field>
+        </record>
+        
+    </data>
+</openerp>

--- a/lost_object/wizard/give_object_view.xml
+++ b/lost_object/wizard/give_object_view.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        
+        <record id="give_object_wiz_view_form" model="ir.ui.view">
+            <field name="name">give.object.wiz.form</field>
+            <field name="model">give.object.wiz</field>
+            <field name="arch" type="xml">
+                <form string="Give Object">
+                    <group>
+                        <field name="lot_id" required="True"/>
+                        <field name="location_id" readonly="True"/>
+                    </group>
+                    <footer>
+                        <button string="Confirm" name="confirm_give_object"
+                                type="object" class="oe_highlight" />
+                        or
+                        <button string="Cancel" class="oe_link"
+                                special="cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="give_object_action" model="ir.actions.act_window">
+            <field name="name">Give object</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">give.object.wiz</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="give_object_wiz_view_form" />
+            <field name="target">new</field>
+        </record>
+        
+    </data>
+</openerp>

--- a/lost_object/wizard/lost_object.py
+++ b/lost_object/wizard/lost_object.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+# © 2015 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, models, fields
+
+
+class GetObjectWiz(models.TransientModel):
+    _name = 'get.object.wiz'
+
+    @api.multi
+    def _default_sequence(self):
+        return self.env['ir.sequence'].next_by_code('lost.object')
+
+    @api.multi
+    def _default_product_id(self):
+        product = self.env.ref('lost_object.product_lost_object', False)
+        return product
+
+    sequence = fields.Char(
+        string='Sequence', default=_default_sequence)
+    product_id = fields.Many2one(
+        comodel_name='product.product', string='Product',
+        default=_default_product_id)
+    description = fields.Char()
+    location_id = fields.Many2one(
+        comodel_name='stock.location', domain=[('usage', '=', 'internal')])
+
+    @api.multi
+    def confirm_get_object_lost(self):
+        location = self.env.ref('lost_object.stock_location_lost')
+        lot = self.env['stock.production.lot'].create({
+            'name': self.sequence,
+            'product_id': self.product_id.id,
+            'ref': self.description})
+        move = self.env['stock.move'].create({
+            'product_uom_qty': 1,
+            'product_id': self.product_id.id,
+            'location_dest_id': self.location_id.id,
+            'name': self.product_id.name,
+            'product_uom': self.product_id.uom_id.id,
+            'location_id': location.id,
+            })
+        move.action_done()
+        quant = self.env['stock.quant'].search([
+            ('history_ids', 'in', move.id)])
+        quant.lot_id = lot
+
+
+class MoveObjectWiz(models.TransientModel):
+    _name = 'move.object.wiz'
+
+    @api.multi
+    def confirm_move_object(self):
+        quant = self.env['stock.quant'].search([
+            ('lot_id', '=', self.lot_id.id)])
+        move = self.env['stock.move'].create({
+            'product_uom_qty': 1,
+            'product_id': self.lot_id.product_id.id,
+            'location_dest_id': self.location_id.id,
+            'name': self.lot_id.product_id.name,
+            'product_uom': self.lot_id.product_id.uom_id.id,
+            'location_id': quant.location_id.id
+            })
+        move.action_done()
+
+    lot_id = fields.Many2one(
+        comodel_name='stock.production.lot', string='Lot',
+        domain=[('quant_ids.location_id.usage', '=', 'internal')])
+    location_id = fields.Many2one(
+        comodel_name='stock.location', domain=[('usage', '=', 'internal')])
+
+
+class GiveObjectWiz(models.TransientModel):
+    _name = 'give.object.wiz'
+
+    def _default_location_id(self):
+        return self.env.ref('lost_object.stock_location_virtual_customer')
+
+    @api.multi
+    def confirm_give_object(self):
+        quant = self.env['stock.quant'].search([
+            ('lot_id', '=', self.lot_id.id)])
+        move = self.env['stock.move'].create({
+            'product_uom_qty': 1,
+            'product_id': self.lot_id.product_id.id,
+            'location_dest_id': self.location_id.id,
+            'name': self.lot_id.product_id.name,
+            'product_uom': self.lot_id.product_id.uom_id.id,
+            'location_id': quant.location_id.id
+            })
+        move.action_done()
+
+    lot_id = fields.Many2one(
+        comodel_name='stock.production.lot', string='Lot',
+        domain=[('quant_ids.location_id.usage', '=', 'internal')])
+    location_id = fields.Many2one(
+        comodel_name='stock.location', default=_default_location_id)

--- a/lost_object/wizard/move_object_view.xml
+++ b/lost_object/wizard/move_object_view.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        
+        <record id="move_object_wiz_view_form" model="ir.ui.view">
+            <field name="name">move.object.wiz.form</field>
+            <field name="model">move.object.wiz</field>
+            <field name="arch" type="xml">
+                <form string="Move Object">
+                    <group>
+                        <field name="lot_id" required="True"/>
+                        <field name="location_id" required="True"/>
+                    </group>
+                    <footer>
+                        <button string="Confirm" name="confirm_move_object"
+                                type="object" class="oe_highlight" />
+                        or
+                        <button string="Cancel" class="oe_link"
+                                special="cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="move_object_action" model="ir.actions.act_window">
+            <field name="name">Move object</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">move.object.wiz</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="move_object_wiz_view_form" />
+            <field name="target">new</field>
+        </record>
+        
+    </data>
+</openerp>


### PR DESCRIPTION
Generar menú aparte "objetos perdidos", a la misma altura que las "reclamaciones"
Debajo de este menú, habrá 3 nuevos menús "entregar objeto", "recoger objeto", "mover objeto"

Al pulsar "recoger objeto", saltará un wizard que mostrará: 
.- Un secuencial objeto perdido que se crea automáticamente
.- Producto: por defecto informado con el producto "objeto perdido"
.- Un campo texto que podrá rellenar el usuario
.- Una ubicación física de las que existen en el sistema
Todos los campos requeridos y editables
Al aceptar el wizard:
.- Se crea un movimiento de almacén con origen objetos perdidos (ubicación virtual, a crear en datos maestros), destino el del wizard, cantidad 1, producto el del wizard
.- Se crea un lote, con nombre: El secuencial del wizard, producto: el del wizard, referencia interna: lo escrito en el campo texto
.- Se "realiza" el movimiento automáticamente y al quant creado, se asigna el lote creado.

-------------

Al pulsar "entregar objeto", Saltará un wizard que mostrará_
.- Un enlace a lote --> Domain: El lote existe en un quant con ubicación física
.- Ubicación virtual clientes (no editable)

Al pulsar "mover objeto", saltará un wizard que mostrará
.- Un enlace a lote: Domain: El lote existe en un quant con ubicación física
.- Una ubicación (domain a ubicaciones físicas, no podrán seleccionar virtuales)