### PR TITLE
[ADD] purchase_order_search_extended: Group purchase orders by week.

### DIFF
--- a/purchase_order_search_extended/README.rst
+++ b/purchase_order_search_extended/README.rst
@@ -1,0 +1,18 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+==============================
+Purchase order search extended
+==============================
+
+* This module allows you to filter purchase orders by order month, order week,
+  date planned month, date planned week.
+
+Credits
+=======
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/purchase_order_search_extended/__init__.py
+++ b/purchase_order_search_extended/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html

--- a/purchase_order_search_extended/__openerp__.py
+++ b/purchase_order_search_extended/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Purchase order search extended",
+    'version': '8.0.1.1.0',
+    'license': "AGPL-3",
+    'author': "AvanzOSC",
+    'website': "http://www.avanzosc.es",
+    'contributors': [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es",
+    ],
+    "category": "Purchase Management",
+    "depends": [
+        'purchase',
+    ],
+    "data": [
+        'views/purchase_order_view.xml'
+    ],
+    "installable": True,
+}

--- a/purchase_order_search_extended/i18n/es.po
+++ b/purchase_order_search_extended/i18n/es.po
@@ -1,0 +1,87 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* purchase_order_search_extended
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-04-19 09:30+0000\n"
+"PO-Revision-Date: 2016-04-19 11:32+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Current month"
+msgstr "Mes en curso"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Current week"
+msgstr "Semana en curso"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Expected Date"
+msgstr "Fecha prevista"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+msgid "Expected Month"
+msgstr "Mes esperado"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Next month"
+msgstr "Mes siguiente"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Next week"
+msgstr "Semana siguiente"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Planned current month"
+msgstr "Planificado mes en curso"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Planned current week"
+msgstr "Planificado semana en curso"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Planned next month"
+msgstr "Planificado siguiente mes"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Planned next week"
+msgstr "Planificado siguiente semana"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Planned week"
+msgstr "Planificado semana"
+
+#. module: purchase_order_search_extended
+#: view:purchase.order:purchase_order_search_extended.view_purchase_order_filter_inh_group_week
+#: view:purchase.order:purchase_order_search_extended.view_request_for_quotation_filter_inh_group_week
+msgid "Week"
+msgstr "Semana"

--- a/purchase_order_search_extended/views/purchase_order_view.xml
+++ b/purchase_order_search_extended/views/purchase_order_view.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_request_for_quotation_filter_inh_group_week" model="ir.ui.view">
+            <field name="name">view.request.for.quotation.filter.inh.group.week</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.view_request_for_quotation_filter" />
+            <field name="arch" type="xml">
+                <field name="create_uid" position="after">
+                    <field name="date_order" />
+                    <field name="minimum_planned_date" />
+                </field>
+                <filter name="not_invoiced" position="after">
+                    <separator/>
+                    <filter string="Current week"
+                            domain="[('date_order','&lt;=', (context_today() + relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
+                                     ('date_order','&gt;',(context_today() - relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]"/>
+                    <filter string="Next week"
+                            domain="[('date_order','&gt;',(context_today()+relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
+                                     ('date_order','&lt;=',(context_today()+relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]" />
+                    <filter string="Current month"
+                            domain="[('date_order','&lt;',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
+                                     ('date_order','&gt;=',time.strftime('%%Y-%%m-01'))]" />
+                    <filter string="Next month"
+                            domain="[('date_order','&gt;=',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
+                                     ('date_order','&lt;',(context_today()+relativedelta(months=2)).strftime('%%Y-%%m-01'))]" />
+                    <separator/>
+                    <filter string="Planned current week"
+                            domain="[('minimum_planned_date','&lt;=', (context_today() + relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
+                                     ('minimum_planned_date','&gt;',(context_today() - relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]"/>
+                    <filter string="Planned next week"
+                            domain="[('minimum_planned_date','&gt;',(context_today()+relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
+                                     ('minimum_planned_date','&lt;=',(context_today()+relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]" />
+                    <filter string="Planned current month"
+                            domain="[('minimum_planned_date','&lt;',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
+                                     ('minimum_planned_date','&gt;=',time.strftime('%%Y-%%m-01'))]" />
+                    <filter string="Planned next month"
+                            domain="[('minimum_planned_date','&gt;=',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
+                                     ('minimum_planned_date','&lt;',(context_today()+relativedelta(months=2)).strftime('%%Y-%%m-01'))]" />
+                </filter>
+                <filter string="Expected Date" position="after">
+                    <filter string="Week" domain="[]" context="{'group_by': 'date_order:week'}"/>
+                    <filter string="Planned week" domain="[]" context="{'group_by': 'minimum_planned_date:week'}"/>
+                </filter>
+            </field>
+        </record>
+        <record id="view_purchase_order_filter_inh_group_week" model="ir.ui.view">
+            <field name="name">view.purchase.order.filter.inh.group.week</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.view_purchase_order_filter" />
+            <field name="arch" type="xml">
+                <field name="create_uid" position="after">
+                    <field name="date_order" />
+                    <field name="minimum_planned_date" />
+                </field>
+                <filter name="message_unread" position="after">
+                    <separator/>
+                    <filter string="Current week"
+                            domain="[('date_order','&lt;=', (context_today() + relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
+                                     ('date_order','&gt;',(context_today() - relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]"/>
+                    <filter string="Next week"
+                            domain="[('date_order','&gt;',(context_today()+relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
+                                     ('date_order','&lt;=',(context_today()+relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]" />
+                    <filter string="Current month"
+                            domain="[('date_order','&lt;',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
+                                     ('date_order','&gt;=',time.strftime('%%Y-%%m-01'))]" />
+                    <filter string="Next month"
+                            domain="[('date_order','&gt;=',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
+                                     ('date_order','&lt;',(context_today()+relativedelta(months=2)).strftime('%%Y-%%m-01'))]" />
+                    <separator/>
+                    <filter string="Planned current week"
+                            domain="[('minimum_planned_date','&lt;=', (context_today() + relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
+                                     ('minimum_planned_date','&gt;',(context_today() - relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]"/>
+                    <filter string="Planned next week"
+                            domain="[('minimum_planned_date','&gt;',(context_today()+relativedelta(weeks=0, weekday=6)).strftime('%%Y-%%m-%%d')),
+                                     ('minimum_planned_date','&lt;=',(context_today()+relativedelta(weeks=1, weekday=6)).strftime('%%Y-%%m-%%d'))]" />
+                    <filter string="Planned current month"
+                            domain="[('minimum_planned_date','&lt;',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
+                                     ('minimum_planned_date','&gt;=',time.strftime('%%Y-%%m-01'))]" />
+                    <filter string="Planned next month"
+                            domain="[('minimum_planned_date','&gt;=',(context_today()+relativedelta(months=1)).strftime('%%Y-%%m-01')),
+                                     ('minimum_planned_date','&lt;',(context_today()+relativedelta(months=2)).strftime('%%Y-%%m-01'))]" />
+                </filter>
+                <filter string="Expected Month" position="after">
+                    <filter string="Week" domain="[]" context="{'group_by': 'date_order:week'}"/>
+                    <filter string="Planned week" domain="[]" context="{'group_by': 'minimum_planned_date:week'}"/>
+                </filter>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Nuevo módulo para poder agrupar pedidos de compra por semana. Se ha puesto el nombre solicitado por @oihane 