### PR TITLE
[IMP] sale_service_recurrence_configurator: New fiel "Week 6", in sal…

### DIFF
--- a/sale_service_recurrence_configurator/i18n/es.po
+++ b/sale_service_recurrence_configurator/i18n/es.po
@@ -1,97 +1,90 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* sale_service_recurrence_configurator
+# 	* sale_service_recurrence_configurator
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-29 09:38+0000\n"
-"PO-Revision-Date: 2016-01-29 09:38+0000\n"
+"POT-Creation-Date: 2016-05-23 09:01+0000\n"
+"PO-Revision-Date: 2016-05-23 11:01+0100\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,april:0
-#: field:sale.quote.line,april:0
+#: field:sale.order.line,april:0 field:sale.quote.line,april:0
 msgid "April"
 msgstr "Abril"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,august:0
-#: field:sale.quote.line,august:0
+#: field:sale.order.line,august:0 field:sale.quote.line,august:0
 msgid "August"
 msgstr "Agosto"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,december:0
-#: field:sale.quote.line,december:0
+#: field:sale.order.line,december:0 field:sale.quote.line,december:0
 msgid "December"
 msgstr "Diciembre"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,february:0
-#: field:sale.quote.line,february:0
+#: field:sale.order.line,february:0 field:sale.quote.line,february:0
 msgid "February"
 msgstr "Febrero"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,friday:0
-#: field:sale.quote.line,friday:0
+#: field:sale.order.line,friday:0 field:sale.quote.line,friday:0
 msgid "Friday"
 msgstr "Viernes"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,january:0
-#: field:sale.quote.line,january:0
+#: field:sale.order.line,january:0 field:sale.quote.line,january:0
 msgid "January"
 msgstr "Enero"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,july:0
-#: field:sale.quote.line,july:0
+#: field:sale.order.line,july:0 field:sale.quote.line,july:0
 msgid "July"
 msgstr "Julio"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,june:0
-#: field:sale.quote.line,june:0
+#: field:sale.order.line,june:0 field:sale.quote.line,june:0
 msgid "June"
 msgstr "Junio"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,march:0
-#: field:sale.quote.line,march:0
+#: field:sale.order.line,march:0 field:sale.quote.line,march:0
 msgid "March"
 msgstr "Marzo"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,may:0
-#: field:sale.quote.line,may:0
+#: field:sale.order.line,may:0 field:sale.quote.line,may:0
 msgid "May"
 msgstr "Mayo"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,monday:0
-#: field:sale.quote.line,monday:0
+#: field:sale.order.line,monday:0 field:sale.quote.line,monday:0
 msgid "Monday"
 msgstr "Lunes"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,november:0
-#: field:sale.quote.line,november:0
+#: field:sale.order.line,november:0 field:sale.quote.line,november:0
 msgid "November"
 msgstr "Noviembre"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,october:0
-#: field:sale.quote.line,october:0
+#: field:sale.order.line,october:0 field:sale.quote.line,october:0
 msgid "October"
 msgstr "Octubre"
+
+#. module: sale_service_recurrence_configurator
+#: model:ir.model,name:sale_service_recurrence_configurator.model_product_product
+msgid "Product"
+msgstr "Producto"
 
 #. module: sale_service_recurrence_configurator
 #: model:ir.model,name:sale_service_recurrence_configurator.model_product_template
@@ -105,7 +98,9 @@ msgid "Quotation Template Lines"
 msgstr "Líneas de plantilla de presupuesto"
 
 #. module: sale_service_recurrence_configurator
+#: field:product.product,recurring_service:0
 #: field:product.template,recurring_service:0
+#: field:sale.order.line,recurring_service:0
 msgid "Recurring Service"
 msgstr "Servicio recurrente"
 
@@ -117,7 +112,7 @@ msgstr "Pedido de venta"
 #. module: sale_service_recurrence_configurator
 #: model:ir.model,name:sale_service_recurrence_configurator.model_sale_order_line
 msgid "Sales Order Line"
-msgstr "Línea de pedido de venta"
+msgstr "Línea pedido de venta"
 
 #. module: sale_service_recurrence_configurator
 #: view:sale.quote.template:sale_service_recurrence_configurator.view_sale_quote_template_form_inh_mwd
@@ -125,68 +120,61 @@ msgid "Sales Quote Template Lines"
 msgstr "Líneas de la plantilla de pedido de venta"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,saturday:0
-#: field:sale.quote.line,saturday:0
+#: field:sale.order.line,saturday:0 field:sale.quote.line,saturday:0
 msgid "Saturday"
 msgstr "Sábado"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,september:0
-#: field:sale.quote.line,september:0
+#: field:sale.order.line,september:0 field:sale.quote.line,september:0
 msgid "September"
 msgstr "Septiembre"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,sunday:0
-#: field:sale.quote.line,sunday:0
+#: field:sale.order.line,sunday:0 field:sale.quote.line,sunday:0
 msgid "Sunday"
 msgstr "Domingo"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,thursday:0
-#: field:sale.quote.line,thursday:0
+#: field:sale.order.line,thursday:0 field:sale.quote.line,thursday:0
 msgid "Thursday"
 msgstr "Jueves"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,tuesday:0
-#: field:sale.quote.line,tuesday:0
+#: field:sale.order.line,tuesday:0 field:sale.quote.line,tuesday:0
 msgid "Tuesday"
 msgstr "Martes"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,wednesday:0
-#: field:sale.quote.line,wednesday:0
+#: field:sale.order.line,wednesday:0 field:sale.quote.line,wednesday:0
 msgid "Wednesday"
 msgstr "Miércoles"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,week1:0
-#: field:sale.quote.line,week1:0
+#: field:sale.order.line,week1:0 field:sale.quote.line,week1:0
 msgid "Week 1"
 msgstr "Semana 1"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,week2:0
-#: field:sale.quote.line,week2:0
+#: field:sale.order.line,week2:0 field:sale.quote.line,week2:0
 msgid "Week 2"
 msgstr "Semana 2"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,week3:0
-#: field:sale.quote.line,week3:0
+#: field:sale.order.line,week3:0 field:sale.quote.line,week3:0
 msgid "Week 3"
 msgstr "Semana 3"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,week4:0
-#: field:sale.quote.line,week4:0
+#: field:sale.order.line,week4:0 field:sale.quote.line,week4:0
 msgid "Week 4"
 msgstr "Semana 4"
 
 #. module: sale_service_recurrence_configurator
-#: field:sale.order.line,week5:0
-#: field:sale.quote.line,week5:0
+#: field:sale.order.line,week5:0 field:sale.quote.line,week5:0
 msgid "Week 5"
 msgstr "Semana 5"
 
+#. module: sale_service_recurrence_configurator
+#: field:sale.order.line,week6:0 field:sale.quote.line,week6:0
+msgid "Week 6"
+msgstr "Semana 6"

--- a/sale_service_recurrence_configurator/models/sale.py
+++ b/sale_service_recurrence_configurator/models/sale.py
@@ -68,6 +68,7 @@ class SaleOrder(models.Model):
                     'week3': template.week3,
                     'week4': template.week4,
                     'week5': template.week5,
+                    'week6': template.week6,
                     'monday': template.monday,
                     'tuesday': template.tuesday,
                     'wednesday': template.wednesday,
@@ -102,6 +103,7 @@ class SaleOrderLine(models.Model):
     week3 = fields.Boolean('Week 3')
     week4 = fields.Boolean('Week 4')
     week5 = fields.Boolean('Week 5')
+    week6 = fields.Boolean('Week 6')
     monday = fields.Boolean('Monday')
     tuesday = fields.Boolean('Tuesday')
     wednesday = fields.Boolean('Wednesday')
@@ -134,6 +136,7 @@ class SaleQuoteLine(models.Model):
     week3 = fields.Boolean('Week 3')
     week4 = fields.Boolean('Week 4')
     week5 = fields.Boolean('Week 5')
+    week6 = fields.Boolean('Week 6')
     monday = fields.Boolean('Monday')
     tuesday = fields.Boolean('Tuesday')
     wednesday = fields.Boolean('Wednesday')

--- a/sale_service_recurrence_configurator/tests/test_sale_service_recurrence_configurator.py
+++ b/sale_service_recurrence_configurator/tests/test_sale_service_recurrence_configurator.py
@@ -27,6 +27,7 @@ class TestSaleServiceRecurrenceConfigurator(TransactionCase):
             'pricelist_id': self.env.ref('product.list0').id,
             'template_id': self.line_template.quote_id.id}
         self.sale_order = self.sale_model.create(sale_vals)
+        self.line_template.quote_id.copy()
 
     def test_sale_service_Recurrence_configurator(self):
         product = self.line_template.product_id

--- a/sale_service_recurrence_configurator/views/sale_order_view.xml
+++ b/sale_service_recurrence_configurator/views/sale_order_view.xml
@@ -30,6 +30,7 @@
                            <field name="week3" />
                            <field name="week4" />
                            <field name="week5" />
+                           <field name="week6" />
                        </group>
                        <group name="group_day" colspan="2" >
                            <field name="monday" />

--- a/sale_service_recurrence_configurator/views/sale_quote_view.xml
+++ b/sale_service_recurrence_configurator/views/sale_quote_view.xml
@@ -40,6 +40,7 @@
                            <field name="week3" />
                            <field name="week4" />
                            <field name="week5" />
+                           <field name="week6" />
                        </group>
                        <group colspan="2" >
                            <field name="monday" />

--- a/stock_information_mrp_procurement_plan/tests/test_stock_information_mrp_procurement_plan.py
+++ b/stock_information_mrp_procurement_plan/tests/test_stock_information_mrp_procurement_plan.py
@@ -43,5 +43,9 @@ class TestStockInformationMrpProcurementPlan(common.TransactionCase):
         plan.button_recalculate_stock_info()
         cond = []
         lines = self.stock_information_model.search(cond)
+        for line in lines:
+            line._compute_week()
+            line.show_incoming_procurements_from_plan()
+            line.show_outgoing_pending_reserved_moves()
         self.assertNotEqual(
             len(lines), 0, 'It has not generated the STOCK INFORMATION')


### PR DESCRIPTION
…e.quote.line, and in sale.order.line

Se ha modificado el módulo para tener en cuenta que un mes puede tener 6 semanas. Es por ello que se ha creado el nuevo campo "week6" in líneas de plantilla de ventas, y en líneas de pedido de venta.
He tenido que ampliar también el test de "stock_information_mrp_procurement_plan", porque me ha bajado el "coveralls".