### PR TITLE
[FIX] quality_control_from_event: fix readme.rst

### DIFF
--- a/quality_control_from_event/README.rst
+++ b/quality_control_from_event/README.rst
@@ -2,7 +2,7 @@
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
-=========================
+==========================
 Quality control from event
 ==========================
 


### PR DESCRIPTION
Se ha arreglado el fichero readme.rst, porque daba error al intentar instalar el módulo.