### PR TITLE
[ADD] calendar_event_without_group: In calendar removes the group in …

### DIFF
--- a/calendar_event_without_group/README.rst
+++ b/calendar_event_without_group/README.rst
@@ -1,0 +1,18 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+============================
+Calendar event without group
+============================
+
+* This module removes the group in tabs "Invitations" and "Misc" tabs. You can
+not change the meeting, if you has not been that created it.
+
+Credits
+=======
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/calendar_event_without_group/__init__.py
+++ b/calendar_event_without_group/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models

--- a/calendar_event_without_group/__openerp__.py
+++ b/calendar_event_without_group/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Calendar Event Without Group",
+    'version': '8.0.1.0.0',
+    'license': "AGPL-3",
+    'author': "AvanzOSC",
+    'website': "http://www.avanzosc.es",
+    'contributors': [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es",
+    ],
+    "category": "Event Management",
+    "depends": [
+        'calendar',
+    ],
+    "data": [
+        "views/calendar_event_view.xml",
+    ],
+    "installable": True,
+}

--- a/calendar_event_without_group/i18n/es.po
+++ b/calendar_event_without_group/i18n/es.po
@@ -1,0 +1,41 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* calendar_event_without_group
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-01 10:01+0000\n"
+"PO-Revision-Date: 2016-09-01 12:01+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: calendar_event_without_group
+#: model:ir.model,name:calendar_event_without_group.model_calendar_event
+msgid "Event"
+msgstr "Evento"
+
+#. module: calendar_event_without_group
+#: view:calendar.event:calendar_event_without_group.view_calendar_event_form_inh_withoutgroup
+msgid "Invitations"
+msgstr "Invitaciones"
+
+#. module: calendar_event_without_group
+#: view:calendar.event:calendar_event_without_group.view_calendar_event_form_inh_withoutgroup
+msgid "Misc"
+msgstr "Misc."
+
+#. module: calendar_event_without_group
+#: code:addons/calendar_event_without_group/models/calendar_event.py:15
+#, python-format
+msgid ""
+"You can not change this meeting, because you are not the user who created it"
+msgstr ""
+"No puede modificar esta reunión, porque usted no es la persona que la ha "
+"creado"

--- a/calendar_event_without_group/models/__init__.py
+++ b/calendar_event_without_group/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import calendar_event

--- a/calendar_event_without_group/models/calendar_event.py
+++ b/calendar_event_without_group/models/calendar_event.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, api, exceptions, _
+
+
+class CalendarEvent(models.Model):
+    _inherit = 'calendar.event'
+
+    @api.multi
+    def write(self, vals):
+        for calendar in self:
+            if calendar.create_uid.id != self.env.uid:
+                raise exceptions.Warning(
+                    _("You can not change this meeting, because you are not "
+                      "the user who created it"))
+        return super(CalendarEvent, self).write(vals)

--- a/calendar_event_without_group/tests/__init__.py
+++ b/calendar_event_without_group/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_calendar_event_without_group

--- a/calendar_event_without_group/tests/test_calendar_event_without_group.py
+++ b/calendar_event_without_group/tests/test_calendar_event_without_group.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016 Alfredo de la Fuente - AvanzOSC
+# © 2016 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+from openerp import exceptions
+
+
+class TestCalendarEventWithoutGroup(common.TransactionCase):
+
+    def setUp(self):
+        super(TestCalendarEventWithoutGroup, self).setUp()
+        self.calendar_event_model = self.env['calendar.event']
+        self.calendar = self.env.ref('calendar.calendar_event_7')
+        self.user_demo = self.ref('base.user_demo')
+
+    def test_sale_order_create_event_by_task(self):
+        with self.assertRaises(exceptions.Warning):
+            self.calendar.sudo(self.user_demo).write({'description': 'a'})

--- a/calendar_event_without_group/views/calendar_event_view.xml
+++ b/calendar_event_without_group/views/calendar_event_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_calendar_event_form_inh_withoutgroup" model="ir.ui.view">
+            <field name="name">view.calendar.event.form.inh.withoutgroup</field>
+            <field name="model">calendar.event</field>
+            <field name="inherit_id" ref="calendar.view_calendar_event_form" />
+            <field name="arch" type="xml">
+                <page string="Invitations" position="attributes">
+                    <attribute name="groups"></attribute>
+                </page>
+                <page string="Misc" position="attributes">
+                    <attribute name="groups"></attribute>
+                </page>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/partner_student_course/tests/test_partner_student_course.py
+++ b/partner_student_course/tests/test_partner_student_course.py
@@ -15,6 +15,7 @@ class TestPartnerStudentCourse(common.TransactionCase):
         today = fields.Date.from_string(fields.Date.today())
         self.partner.birthdate_date = (fields.Date.to_string(
             today + relativedelta(years=-3)))
+        self.partner.student_repeated_courses = True
         count = 0
         while count <= 5:
             course_vals = {'age': count,


### PR DESCRIPTION
…tabs "Invitations" and "Misc" tabs.
Quitar el grupo de las pestañas "Invitados", y "Misc" de reuniones. En la siguiente subida, he hecho que un usuario no pueda modificar la reunión, si no ha sido el quién la ha creado. Esto me lo han pedido después de la primera subida.
