### PR TITLE
[ADD] new module: stock_move_capture, dependencies modified

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -12,3 +12,4 @@ hr https://github.com/OCA/hr.git
 # Add a repository url and branch if you need a forked version
 serviciosbaeza-odooaddons https://github.com/serviciosbaeza/serviciosbaeza-odoo-addons.git
 mrp-repair-addons https://github.com/avanzosc/mrp-repair-addons
+vauxoo https://github.com/Vauxoo/addons-vauxoo

--- a/stock_move_capture/README.rst
+++ b/stock_move_capture/README.rst
@@ -1,0 +1,21 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================
+Stock Move Capture
+==================
+
+* This module create stock move from a wizard.
+* It also creates a new menu entry "Move Capture" to open that wizard.
+* If the wizard is confirmed every move will be done.
+
+
+Credits
+=======
+
+
+Contributors
+------------
+* Esther Martín <esthermartin@avanzosc.es>
+* Ana Juaristi <anajuaristi@avanzosc.es>

--- a/stock_move_capture/__init__.py
+++ b/stock_move_capture/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import models
+from . import wizard

--- a/stock_move_capture/__openerp__.py
+++ b/stock_move_capture/__openerp__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# © 2016 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Stock Move Capture",
+    "version": "8.0.1.0.0",
+    "category": "Custom Module",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Esther Martín <esthermartin@avanzosc.es>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+    ],
+    "depends": [
+        "stock_location_code",
+    ],
+    "data": [
+        "views/stock_view.xml",
+        "wizard/capture_move_view.xml",
+    ],
+    "installable": True,
+}

--- a/stock_move_capture/i18n/es.po
+++ b/stock_move_capture/i18n/es.po
@@ -1,0 +1,132 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* stock_move_capture
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-09-22 07:40+0000\n"
+"PO-Revision-Date: 2016-09-22 09:47+0100\n"
+"Last-Translator: Esther Martín <esthermartin@avanzosc.es>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: stock_move_capture
+#: view:capture.move:stock_move_capture.capture_move_view_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: stock_move_capture
+#: model:ir.actions.act_window,name:stock_move_capture.action_capture_move
+#: model:ir.model,name:stock_move_capture.model_capture_move
+#: model:ir.ui.menu,name:stock_move_capture.menu_capture_move
+msgid "Capture moves"
+msgstr "Capturar movimientos"
+
+#. module: stock_move_capture
+#: view:capture.move:stock_move_capture.capture_move_view_form
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: stock_move_capture
+#: field:capture.move,create_uid:0 field:product.move,create_uid:0
+msgid "Created by"
+msgstr "Creador por"
+
+#. module: stock_move_capture
+#: field:capture.move,create_date:0 field:product.move,create_date:0
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: stock_move_capture
+#: field:product.move,location_dest_id:0
+msgid "Destination Location"
+msgstr "Ubicación destino"
+
+#. module: stock_move_capture
+#: field:capture.move,display_name:0 field:product.move,display_name:0
+msgid "Display Name"
+msgstr "Display Name"
+
+#. module: stock_move_capture
+#: field:capture.move,id:0 field:product.move,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: stock_move_capture
+#: view:capture.move:stock_move_capture.capture_move_view_form
+msgid "Import Inventory"
+msgstr "Import Inventory"
+
+#. module: stock_move_capture
+#: field:capture.move,__last_update:0 field:product.move,__last_update:0
+msgid "Last Modified on"
+msgstr "Última modificación en"
+
+#. module: stock_move_capture
+#: field:capture.move,write_uid:0 field:product.move,write_uid:0
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: stock_move_capture
+#: field:capture.move,write_date:0 field:product.move,write_date:0
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: stock_move_capture
+#: field:product.move,location_id:0
+msgid "Location"
+msgstr "Ubación origen"
+
+#. module: stock_move_capture
+#: field:product.move,move_id:0
+msgid "Move id"
+msgstr "Move id"
+
+#. module: stock_move_capture
+#: code:addons/stock_move_capture/wizard/capture_move.py:53
+#, python-format
+msgid "Picking"
+msgstr "Albarán"
+
+#. module: stock_move_capture
+#: field:product.move,product_id:0
+msgid "Product"
+msgstr "Producto"
+
+#. module: stock_move_capture
+#: model:ir.model,name:stock_move_capture.model_product_move
+msgid "Product moves"
+msgstr "Movimientos de producto"
+
+#. module: stock_move_capture
+#: field:capture.move,product_ids:0
+msgid "Products"
+msgstr "Productos"
+
+#. module: stock_move_capture
+#: field:product.move,quantity:0
+msgid "Quantity"
+msgstr "Cantidad"
+
+#. module: stock_move_capture
+#: field:stock.warehouse,cap_type_id:0
+msgid "Tipo captura"
+msgstr "Tipo captura"
+
+#. module: stock_move_capture
+#: field:capture.move,warehouse_id:0
+#: model:ir.model,name:stock_move_capture.model_stock_warehouse
+msgid "Warehouse"
+msgstr "Almacén"
+
+#. module: stock_move_capture
+#: code:addons/stock_move_capture/wizard/capture_move.py:40
+#, python-format
+msgid "You need to select a capture picking for the warehouse!"
+msgstr "Necesitas seleccionar un albarán de captura para este almacen"

--- a/stock_move_capture/models/__init__.py
+++ b/stock_move_capture/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import stock

--- a/stock_move_capture/models/stock.py
+++ b/stock_move_capture/models/stock.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# © 2016 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, fields
+
+
+class StockWarehouse(models.Model):
+    _inherit = 'stock.warehouse'
+
+    cap_type_id = fields.Many2one(
+        comodel_name='stock.picking.type', string='Tipo captura')

--- a/stock_move_capture/tests/__init__.py
+++ b/stock_move_capture/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import test_stock_move_capture

--- a/stock_move_capture/tests/test_stock_move_capture.py
+++ b/stock_move_capture/tests/test_stock_move_capture.py
@@ -34,3 +34,5 @@ class TestStockMoveCapture(common.TransactionCase):
         self.assertEqual(moves.product_id, products.product_id)
         self.assertEqual(moves.location_id, products.location_id)
         self.assertEqual(moves.location_dest_id, products.location_dest_id)
+        self.assertEqual(moves.state, 'done')
+        self.assertEqual(pick.state, 'done')

--- a/stock_move_capture/tests/test_stock_move_capture.py
+++ b/stock_move_capture/tests/test_stock_move_capture.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# © 2016 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+import openerp.tests.common as common
+from openerp import exceptions
+
+
+class TestStockMoveCapture(common.TransactionCase):
+
+    def setUp(self):
+        super(TestStockMoveCapture, self).setUp()
+        self.warehouse = self.env.ref('stock.warehouse0')
+        self.wiz = self.env['capture.move'].create({
+            'warehouse_id': self.warehouse.id,
+            'product_ids': [(0, 0, {
+                'product_id': self.ref('product.imac'),
+                'quantity': 5,
+                'location_id': self.ref('stock.stock_location_stock'),
+                'location_dest_id': self.ref('stock.stock_location_customers'),
+            })],
+        })
+        self.pick_model = self.env['stock.picking']
+
+    def test_action_confirm_move(self):
+        with self.assertRaises(exceptions.Warning):
+            res = self.wiz.action_confirm_move()
+        self.warehouse.cap_type_id = self.ref('stock.picking_type_out')
+        res = self.wiz.action_confirm_move()
+        pick = self.pick_model.browse(res['res_id'])
+        self.assertEqual(pick.picking_type_id, self.warehouse.cap_type_id)
+        moves = pick.move_lines[0]
+        products = self.wiz.product_ids[0]
+        self.assertEqual(moves.product_id, products.product_id)
+        self.assertEqual(moves.location_id, products.location_id)
+        self.assertEqual(moves.location_dest_id, products.location_dest_id)

--- a/stock_move_capture/views/stock_view.xml
+++ b/stock_move_capture/views/stock_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record id="stock_warehouse_picking_view_form" model="ir.ui.view" >
+            <field name="name">stock.warehouse.picking.form</field>
+            <field name="model">stock.warehouse</field>
+            <field name="inherit_id" ref="stock.view_warehouse" />
+            <field name="arch" type="xml">
+                <field name="out_type_id" position="after">
+                    <field name="cap_type_id" required="True" domain="[('warehouse_id','=', id)]" context="{'default_warehouse_id':active_id}"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/stock_move_capture/wizard/__init__.py
+++ b/stock_move_capture/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import capture_move

--- a/stock_move_capture/wizard/capture_move.py
+++ b/stock_move_capture/wizard/capture_move.py
@@ -26,21 +26,21 @@ class CaptureMove(models.TransientModel):
     def action_confirm_move(self):
         picking_obj = self.env['stock.picking']
         move_lines = []
+        if not self.warehouse_id.cap_type_id:
+            raise exceptions.Warning(
+                _('You need to select a capture picking for the warehouse!'))
         for line in self.product_ids:
-            move_lines.append({
+            move_lines += [(0, 0, {
                 'product_id': line.product_id.id,
                 'product_uom': line.product_id.uom_id.id,
                 'product_uom_qty': line.quantity,
                 'location_id': line.location_id.id,
                 'location_dest_id': line.location_dest_id.id,
                 'name': line.product_id.name,
-            })
-        if not self.warehouse_id.cap_type_id:
-            raise exceptions.Warning(
-                _('You need to select a capture picking for the warehouse!'))
+            })]
         picking = picking_obj.create({
             'picking_type_id': self.warehouse_id.cap_type_id.id,
-            'move_lines': [(0, 0, x) for x in move_lines],
+            'move_lines': move_lines,
         })
         picking.action_confirm()
         picking.action_assign()

--- a/stock_move_capture/wizard/capture_move.py
+++ b/stock_move_capture/wizard/capture_move.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# © 2016 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import _, api, exceptions, fields, models
+
+
+class CaptureMove(models.TransientModel):
+    _name = 'capture.move'
+    _description = 'Capture moves'
+
+    def _default_warehouse_id(self):
+        warehouse_obj = self.env['stock.warehouse']
+        warehouse = warehouse_obj.search([])
+        if len(warehouse) == 1:
+            return warehouse.id
+        return self.env['stock.warehouse']
+
+    warehouse_id = fields.Many2one(
+        comodel_name='stock.warehouse', string='Warehouse',
+        default=_default_warehouse_id)
+    product_ids = fields.One2many(
+        comodel_name='product.move', inverse_name='move_id', string='Products')
+
+    @api.multi
+    def action_confirm_move(self):
+        picking_obj = self.env['stock.picking']
+        move_lines = []
+        for line in self.product_ids:
+            move_lines.append({
+                'product_id': line.product_id.id,
+                'product_uom': line.product_id.uom_id.id,
+                'product_uom_qty': line.quantity,
+                'location_id': line.location_id.id,
+                'location_dest_id': line.location_dest_id.id,
+                'name': line.product_id.name,
+            })
+        if not self.warehouse_id.cap_type_id:
+            raise exceptions.Warning(
+                _('You need to select a capture picking for the warehouse!'))
+        picking = picking_obj.create({
+            'picking_type_id': self.warehouse_id.cap_type_id.id,
+            'move_lines': [(0, 0, x) for x in move_lines],
+        })
+        picking.action_confirm()
+        picking.action_assign()
+        picking.force_assign()
+        wiz_view = picking.do_enter_transfer_details()
+        wiz = self.env['stock.transfer_details'].browse(wiz_view['res_id'])
+        wiz.with_context(
+            active_id=wiz_view['context']['active_id']).do_detailed_transfer()
+        return {
+            'name': _('Picking'),
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'stock.picking',
+            'view_id': self.env.ref('stock.view_picking_form').id,
+            'type': 'ir.actions.act_window',
+            'target': 'current',
+            'readonly': True,
+            'res_id': picking.id,
+            'context': self.env.context
+            }
+
+
+class ProductMove(models.TransientModel):
+    _name = 'product.move'
+    _description = 'Product moves'
+
+    quantity = fields.Integer(string='Quantity')
+    product_id = fields.Many2one(
+        comodel_name='product.product', string='Product')
+    location_id = fields.Many2one(
+        comodel_name='stock.location', string='Location')
+    location_dest_id = fields.Many2one(
+        comodel_name='stock.location', string='Destination Location')
+    move_id = fields.Many2one(comodel_name='capture.move')

--- a/stock_move_capture/wizard/capture_move_view.xml
+++ b/stock_move_capture/wizard/capture_move_view.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="capture_move_view_form" model="ir.ui.view">
+            <field name="name">capture.move.form</field>
+            <field name="model">capture.move</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Import Inventory">
+                    <group colspan="4" col="4">
+                        <field name="warehouse_id" colspan="4" required="True"/>
+                        <field name="product_ids" nolabel="1" colspan="4" >
+                            <tree editable="top">
+                                <field name="product_id" required="True"/>
+                                <field name="quantity" />
+                                <field name="location_id" required="True" domain="[('usage','!=','view')]"/>
+                                <field name="location_dest_id" required="True" domain="[('usage','!=','view')]"/>
+                            </tree>
+                        </field>
+                    </group>
+                    <footer>
+                        <button name="action_confirm_move" string="Confirm" type="object"/>
+                        <button class="oe_highlight" special="cancel" string="Cancel"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_capture_move" model="ir.actions.act_window">
+            <field name="name">Capture moves</field>
+            <field name="res_model">capture.move</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_id" ref="capture_move_view_form"/>
+            <field name="target">new</field>
+        </record>
+        
+        <menuitem id="menu_capture_move" name="Capture moves" action="action_capture_move" parent="stock.menu_traceability"/>
+    </data>
+</openerp>


### PR DESCRIPTION
Enfoque técnico: .- Crear una nueva entrada de menú: captura movimientos .
- En almacen añadir un campo many2one a "tipo de albarán" --> Los albaranes creados con el wizard serán de este tipo. 
- Al pulsar el menú salta un wizard con los siguientes datos:
  - Almacén: Many2one a Almacenes --> Si solo hay uno, poner ese y ocultar el campo. 
    Una tabla con los siguientes campos:  
    -  Cantidad producto: many2one a producto --> El search debe hacerse por  default-code o código de barras del producto
    - ubicación origen: many2one a ubicación --> El search debe hacerse por campo  Código de barras de ubicación
    - ubicación destino:many2one a ubicación  -->  El search debe hacerse por campo  Código de barras de ubicación
- Al pulsar confirmar en la ventana -->
  - Crear una cabecera de albarán del tipo  que consta en el almacén indicado en la cabecera del wizard. 
  - Crear un movimiento de almacén con cada uno de los movimientos del wizard 
  - Asegurar que los movimientos, tienen las ubicaciones origen y destino, las especificadas en el wizard. 
  - Clickar por código el botón "comprobar disponibilidad" de cada movimiento.
  - Realizar cada movimiento - Si es necesario y no se queda realizado --> realizar el albarán interno.
