### PR TITLE
[MOD] sale_mrp_link: set price_unit and product_uom_qty from mrp_production

### DIFF
--- a/sale_mrp_link/__openerp__.py
+++ b/sale_mrp_link/__openerp__.py
@@ -19,7 +19,6 @@
         "sale_product_variants",
         "mrp_production_estimated_cost",
         "mrp_product_variants",
-        "mrp_supplier_price",
     ],
     "data": [
         "views/sale_view.xml",

--- a/sale_mrp_link/__openerp__.py
+++ b/sale_mrp_link/__openerp__.py
@@ -19,6 +19,7 @@
         "sale_product_variants",
         "mrp_production_estimated_cost",
         "mrp_product_variants",
+        "mrp_supplier_price",
     ],
     "data": [
         "views/sale_view.xml",

--- a/sale_mrp_link/models/sale.py
+++ b/sale_mrp_link/models/sale.py
@@ -13,6 +13,18 @@ class SaleOrderLine(models.Model):
     product_line_ids = fields.One2many(
         comodel_name='mrp.production.product.line',
         inverse_name='sale_line_id', string='Product line')
+    product_uom_qty = fields.Float(compute='_compute_product_price')
+    price_unit = fields.Float(compute='_compute_product_price')
+
+    @api.multi
+    @api.depends('mrp_production_id', 'mrp_production_id.product_qty',
+                 'mrp_production_id.production_total')
+    def _compute_product_price(self):
+        for line in self:
+            if line.mrp_production_id:
+                line.price_unit = (line.mrp_production_id.production_total /
+                                   line.mrp_production_id.product_qty)
+                line.product_uom_qty = line.mrp_production_id.product_qty
 
     @api.multi
     def need_procurement(self):

--- a/sale_mrp_link/models/sale.py
+++ b/sale_mrp_link/models/sale.py
@@ -13,18 +13,19 @@ class SaleOrderLine(models.Model):
     product_line_ids = fields.One2many(
         comodel_name='mrp.production.product.line',
         inverse_name='sale_line_id', string='Product line')
-    product_uom_qty = fields.Float(compute='_compute_product_price')
-    price_unit = fields.Float(compute='_compute_product_price')
+    product_uom_qty = fields.Float(
+        string='Quantity', compute='_compute_product_price')
+    price_unit = fields.Float(
+        string='Price Unit', compute='_compute_product_price')
 
     @api.multi
     @api.depends('mrp_production_id', 'mrp_production_id.product_qty',
                  'mrp_production_id.production_total')
     def _compute_product_price(self):
-        for line in self:
-            if line.mrp_production_id:
-                line.price_unit = (line.mrp_production_id.production_total /
-                                   line.mrp_production_id.product_qty)
-                line.product_uom_qty = line.mrp_production_id.product_qty
+        for line in self.filtered(lambda x: x.mrp_production_id):
+            line.price_unit = (line.mrp_production_id.production_total /
+                               line.mrp_production_id.product_qty)
+            line.product_uom_qty = line.mrp_production_id.product_qty
 
     @api.multi
     def need_procurement(self):

--- a/sale_mrp_link/tests/test_sale_mrp_link.py
+++ b/sale_mrp_link/tests/test_sale_mrp_link.py
@@ -18,7 +18,7 @@ class TestSaleMrpLink(common.TransactionCase):
             'product_tmpl_id': self.product.product_tmpl_id.id,
             'product_id': self.product.id,
             'name': self.product.name,
-            'product_uos_qty': 7,
+            'product_uom_qty': 7,
             'product_uom': self.product.uom_id.id,
             'price_unit': self.product.list_price,
             'order_id': self.sale.id,
@@ -27,7 +27,7 @@ class TestSaleMrpLink(common.TransactionCase):
             'product_tmpl_id': self.product2.product_tmpl_id.id,
             'product_id': self.product2.id,
             'name': self.product2.name,
-            'product_uos_qty': 7,
+            'product_uom_qty': 7,
             'product_uom': self.product2.uom_id.id,
             'price_unit': self.product2.list_price,
             'order_id': self.sale.id,
@@ -42,6 +42,11 @@ class TestSaleMrpLink(common.TransactionCase):
         self.assertEqual(sale_line.product_line_ids, production.product_lines)
         self.assertEqual(sale_line, production.sale_line)
         self.assertEqual(self.sale, production.sale_order)
+        production.product_qty = 5
+        production.product_lines[0].cost = 50
+        self.assertEqual(sale_line.product_uom_qty, production.product_qty)
+        self.assertEqual(
+            sale_line.price_unit, production.product_lines[0].cost)
         virtual = production.name
         self.sale.action_button_confirm()
         self.assertNotEqual(virtual, production.name)

--- a/sale_mrp_link/tests/test_sale_mrp_link.py
+++ b/sale_mrp_link/tests/test_sale_mrp_link.py
@@ -9,20 +9,10 @@ class TestSaleMrpLink(common.TransactionCase):
 
     def setUp(self):
         super(TestSaleMrpLink, self).setUp()
-        self.product = self.env.ref('product.product_product_4')
+        self.sale = self.env.ref('sale.sale_order_6')
         self.product2 = self.env.ref('product.product_product_3')
-        self.sale = self.env.ref('sale.sale_order_1')
 
     def test_add_mrp_production(self):
-        sale_line_vals = {
-            'product_tmpl_id': self.product.product_tmpl_id.id,
-            'product_id': self.product.id,
-            'name': self.product.name,
-            'product_uom_qty': 7,
-            'product_uom': self.product.uom_id.id,
-            'price_unit': self.product.list_price,
-            'order_id': self.sale.id,
-            }
         sale_line_vals2 = {
             'product_tmpl_id': self.product2.product_tmpl_id.id,
             'product_id': self.product2.id,
@@ -32,8 +22,8 @@ class TestSaleMrpLink(common.TransactionCase):
             'price_unit': self.product2.list_price,
             'order_id': self.sale.id,
             }
-        sale_line = self.env['sale.order.line'].create(sale_line_vals)
         sale_line2 = self.env['sale.order.line'].create(sale_line_vals2)
+        sale_line = self.sale.order_line[0]
         sale_line.action_create_mrp()
         self.assertTrue(sale_line.mrp_production_id)
         self.assertTrue(sale_line2.need_procurement())
@@ -46,7 +36,8 @@ class TestSaleMrpLink(common.TransactionCase):
         production.product_lines[0].cost = 50
         self.assertEqual(sale_line.product_uom_qty, production.product_qty)
         self.assertEqual(
-            sale_line.price_unit, production.product_lines[0].cost)
+            sale_line.price_unit,
+            production.production_total / production.product_qty)
         virtual = production.name
         self.sale.action_button_confirm()
         self.assertNotEqual(virtual, production.name)


### PR DESCRIPTION
Al modificar la cantidad de la orden de producción o el total del coste, debería de pasar ambos valores a la línea de pedido.
@avanzosc/developers review pls :)