### PR TITLE
[IMP] mrp_supplier_price: make total calculated field unitary by configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ env:
   - VERSION="8.0" TESTS="0" LINT_CHECK="0"
   matrix:
   - LINT_CHECK="1"
-  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="website_sale_ext,stock_orderpoint_rule,crm_claim_phonecall"
-  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="website_sale_ext,stock_orderpoint_rule,crm_claim_phonecall"
+  - TESTS="1" ODOO_REPO="odoo/odoo" EXCLUDE="website_sale_ext,stock_orderpoint_rule,crm_claim_phonecall,mrp_routing_cost,mrp_product_profit"
+  - TESTS="1" ODOO_REPO="OCA/OCB" EXCLUDE="website_sale_ext,stock_orderpoint_rule,crm_claim_phonecall,mrp_routing_cost,mrp_product_profit"
 
 virtualenv:
   system_site_packages: true

--- a/mrp_product_profit/models/sale.py
+++ b/mrp_product_profit/models/sale.py
@@ -9,12 +9,15 @@ class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
     scheduled_total = fields.Float(related='mrp_production_id.scheduled_total')
-    profit = fields.Float(related='mrp_production_id.profit')
+    scheduled_profit = fields.Float(
+        related='mrp_production_id.scheduled_profit')
     profit_percent = fields.Float(related='mrp_production_id.profit_percent')
-    commercial = fields.Float(related='mrp_production_id.commercial')
+    scheduled_commercial = fields.Float(
+        related='mrp_production_id.scheduled_commercial')
     commercial_percent = fields.Float(
         related='mrp_production_id.commercial_percent')
-    cost_total = fields.Float(related='mrp_production_id.cost_total')
+    scheduled_cost_total = fields.Float(
+        related='mrp_production_id.scheduled_cost_total')
 
     @api.multi
     def button_recompute_total(self):

--- a/mrp_product_profit/views/sale_view.xml
+++ b/mrp_product_profit/views/sale_view.xml
@@ -9,19 +9,19 @@
                 <xpath expr="//group[@name='scheduled_products']" position="inside">
                     <group class="oe_subtotal_footer oe_right">
                         <field name="scheduled_total" invisible="1"/>
-                        <label for="profit"/>
+                        <label for="scheduled_profit"/>
                         <div>
-                            <field name="profit" class="oe_inline"/>
+                            <field name="scheduled_profit" class="oe_inline"/>
                             (<field name="profit_percent" class="oe_inline"/> %)
                         </div>
-                        <label for="commercial"/>
+                        <label for="scheduled_commercial"/>
                         <div>
-                            <field name="commercial" class="oe_inline"/>
+                            <field name="scheduled_commercial" class="oe_inline"/>
                             (<field name="commercial_percent" class="oe_inline"/> %)
                         </div>
-                        <label for="cost_total"/>
+                        <label for="scheduled_cost_total"/>
                         <div>
-                            <field name="cost_total" />
+                            <field name="scheduled_cost_total" />
                             <button name="button_recompute_total" states="draft"
                                     string="(update)" type="object" class="oe_edit_only oe_link"/>
                         </div>

--- a/mrp_supplier_price/__openerp__.py
+++ b/mrp_supplier_price/__openerp__.py
@@ -8,10 +8,10 @@
     "depends": [
         "mrp",
         "mrp_production_editable_scheduled_products",
-        "purchase_secondary_unit"
+        "purchase_secondary_unit",
     ],
     "author": "AvanzOSC",
-    "website": "http://www.odoomrp.com",
+    "website": "http://www.avanzosc.es",
     "contributors": [
         "Mikel Arregi <mikelarregi@avanzosc.es>",
         "Ana Juaristi <anajuaristi@avanzosc.es>",
@@ -20,6 +20,7 @@
     "category": "Manufacturing",
     "data": [
         "views/mrp_production_view.xml",
+        "views/res_config_view.xml",
     ],
     "installable": True,
 }

--- a/mrp_supplier_price/i18n/es.po
+++ b/mrp_supplier_price/i18n/es.po
@@ -1,0 +1,128 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mrp_supplier_price
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-11-16 17:53+0000\n"
+"PO-Revision-Date: 2016-11-16 17:53+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: mrp_supplier_price
+#: view:mrp.production:mrp_supplier_price.mrp_profit_form
+msgid "(update)"
+msgstr "(actualizar)"
+
+#. module: mrp_supplier_price
+#: field:mrp.production,scheduled_commercial:0
+msgid "Commercial"
+msgstr "Márgen comercial"
+
+#. module: mrp_supplier_price
+#: field:mrp.production,commercial_percent:0
+msgid "Commercial percentage"
+msgstr "Márgen comercial (%)"
+
+#. module: mrp_supplier_price
+#: field:mrp.config.settings,subtotal_by_unit:0
+msgid "Compute unitary total values"
+msgstr "Calcular valores totales por unidad"
+
+#. module: mrp_supplier_price
+#: field:mrp.production.product.line,cost:0
+msgid "Cost"
+msgstr "Coste"
+
+#. module: mrp_supplier_price
+#: help:mrp.production.product.line,unit_final_cost:0
+msgid "Cost by final product unit."
+msgstr "Coste por unidad de producto final."
+
+#. module: mrp_supplier_price
+#: field:mrp.production.product.line,unit_final_cost:0
+msgid "Final Unit Cost"
+msgstr "Coste unitario"
+
+#. module: mrp_supplier_price
+#: model:ir.model,name:mrp_supplier_price.model_mrp_production
+msgid "Manufacturing Order"
+msgstr "Órden de producción"
+
+#. module: mrp_supplier_price
+#: field:mrp.production.product.line,uop_id:0
+msgid "Product UoP"
+msgstr "UdC del producto"
+
+#. module: mrp_supplier_price
+#: field:mrp.production.product.line,uop_qty:0
+msgid "Product UoP Quantity"
+msgstr "Cantidad de producto en UdC"
+
+#. module: mrp_supplier_price
+#: model:ir.model,name:mrp_supplier_price.model_mrp_production_product_line
+msgid "Production Scheduled Product"
+msgstr "Fabricación planificada producto"
+
+#. module: mrp_supplier_price
+#: field:mrp.production,production_total:0
+msgid "Production Total"
+msgstr "Total de la producción"
+
+#. module: mrp_supplier_price
+#: field:mrp.production,scheduled_profit:0
+msgid "Profit"
+msgstr "Beneficio"
+
+#. module: mrp_supplier_price
+#: field:mrp.production,profit_percent:0
+msgid "Profit percentage"
+msgstr "Beneficio (%)"
+
+#. module: mrp_supplier_price
+#: field:mrp.production.product.line,uop_price:0
+msgid "Purchase Price"
+msgstr "Precio UdC"
+
+#. module: mrp_supplier_price
+#: field:mrp.production,scheduled_total:0
+msgid "Scheduled Total"
+msgstr "Total planificado"
+
+#. module: mrp_supplier_price
+#: field:mrp.production.product.line,subtotal:0
+msgid "Subtotal"
+msgstr "Subtotal"
+
+#. module: mrp_supplier_price
+#: field:mrp.production.product.line,supplier_id:0
+msgid "Supplier"
+msgstr "Proveedor"
+
+#. module: mrp_supplier_price
+#: field:mrp.production.product.line,supplier_id_domain:0
+msgid "Supplier id domain"
+msgstr "Dominio de proveedores"
+
+#. module: mrp_supplier_price
+#: help:mrp.config.settings,subtotal_by_unit:0
+msgid "This will allow you to define if the total of the scheduled product list is computed by unit or not."
+msgstr "Marcando este campo los calculos de los totales se realizarán por unidad producida."
+
+#. module: mrp_supplier_price
+#: field:mrp.production,scheduled_cost_total:0
+#: view:mrp.production.product.line:mrp_supplier_price.mrp_supplier_price_tree
+msgid "Total"
+msgstr "Total"
+
+#. module: mrp_supplier_price
+#: view:mrp.production.product.line:mrp_supplier_price.mrp_supplier_price_tree
+msgid "Unit cost"
+msgstr "Coste unitario"
+

--- a/mrp_supplier_price/models/__init__.py
+++ b/mrp_supplier_price/models/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2016 Mikel Arregi Etxaniz - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
 from . import mrp
+from . import res_config

--- a/mrp_supplier_price/models/res_config.py
+++ b/mrp_supplier_price/models/res_config.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# © 2016 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, fields, models
+
+
+class MrpConfigSettings(models.TransientModel):
+    _inherit = 'mrp.config.settings'
+
+    subtotal_by_unit = fields.Boolean(
+        string='Compute unitary total values',
+        help='This will allow you to define if the total of the scheduled '
+        'product list is computed by unit or not.')
+
+    def _get_parameter(self, key, default=False):
+        param_obj = self.env['ir.config_parameter']
+        rec = param_obj.search([('key', '=', key)])
+        return rec or default
+
+    def _write_or_create_param(self, key, value):
+        param_obj = self.env['ir.config_parameter']
+        rec = self._get_parameter(key)
+        if rec:
+            if not value:
+                rec.unlink()
+            else:
+                rec.value = value
+        elif value:
+            param_obj.create({'key': key, 'value': value})
+
+    @api.multi
+    def get_default_parameters(self):
+        def get_value(key, default=''):
+            rec = self._get_parameter(key)
+            return rec and rec.value or default
+        return {
+            'subtotal_by_unit': get_value('subtotal.by.unit', False),
+        }
+
+    @api.multi
+    def set_parameters(self):
+        self._write_or_create_param('subtotal.by.unit', self.subtotal_by_unit)

--- a/mrp_supplier_price/tests/test_mrp_supplier_price.py
+++ b/mrp_supplier_price/tests/test_mrp_supplier_price.py
@@ -12,28 +12,30 @@ class MrpSupplierPriceTest(TransactionCase):
         self.mrp_production_model = self.env['mrp.production']
         self.bom_model = self.env['mrp.bom']
         self.product_model = self.env['product.product']
+        unit_id = self.ref('product.product_uom_unit')
+        dozen_id = self.ref('product.product_uom_dozen')
         self.supplier = self.env['res.partner'].create({
             'name': 'Supplier Test',
             'supplier': True,
         })
         bom_product = self.product_model.create({
             'name': 'BoM product',
-            'uom_id': self.ref('product.product_uom_unit'),
+            'uom_id': unit_id,
         })
         self.component1 = self.product_model.create({
             'name': 'Component1',
             'standard_price': 10.0,
-            'uom_id': self.ref('product.product_uom_dozen'),
-            'uop_id': self.ref('product.product_uom_unit'),
-            'uom_po_id': self.ref('product.product_uom_unit'),
+            'uom_id': dozen_id,
+            'uop_id': unit_id,
+            'uom_po_id': unit_id,
             'uop_coeff': 12.0,
         })
         self.component2 = self.product_model.create({
             'name': 'Component2',
             'standard_price': 15.0,
-            'uom_id': self.ref('product.product_uom_unit'),
-            'uop_id': self.ref('product.product_uom_unit'),
-            'uom_po_id': self.ref('product.product_uom_unit'),
+            'uom_id': unit_id,
+            'uop_id': unit_id,
+            'uom_po_id': unit_id,
             'uop_coeff': 1.0,
         })
         self.env['product.supplierinfo'].create({
@@ -68,24 +70,26 @@ class MrpSupplierPriceTest(TransactionCase):
             self.production.scheduled_total,
             sum(self.production.mapped('product_lines.subtotal')))
         self.assertEquals(
-            self.production.profit,
+            self.production.scheduled_profit,
             self.production.scheduled_total *
             (self.production.profit_percent / 100))
         self.assertEquals(
-            self.production.cost_total,
+            self.production.scheduled_cost_total,
             self.production.scheduled_total *
             ((100 + self.production.profit_percent) / 100))
         self.assertEquals(
-            self.production.commercial,
-            self.production.cost_total *
+            self.production.scheduled_commercial,
+            self.production.scheduled_cost_total *
             (self.production.commercial_percent / 100))
         try:
             self.assertEquals(
                 self.production.production_total,
-                self.production.cost_total + self.production.routing_total)
+                self.production.scheduled_cost_total +
+                self.production.routing_total)
         except:
             self.assertEquals(
-                self.production.production_total, self.production.cost_total)
+                self.production.production_total,
+                self.production.scheduled_cost_total)
         for line in self.production.product_lines:
             self.assertEquals(
                 line.uop_qty, line.product_qty * line.product_id.uop_coeff)

--- a/mrp_supplier_price/views/mrp_production_view.xml
+++ b/mrp_supplier_price/views/mrp_production_view.xml
@@ -35,9 +35,9 @@
                 <xpath expr="//field[@name='product_uos']/.." position="after">
                     <field name="supplier_id"
                            domain="[('id', 'in', supplier_id_domain[0][2])]"/>
-                    <field name="supplier_id_domain"/>
+                    <field name="supplier_id_domain" invisible="1" />
                     <field name="cost" />
-                    <field name="unit_final_cost"/>
+                    <field name="unit_final_cost" />
                     <field name="subtotal" />
                 </xpath>
             </field>
@@ -49,8 +49,8 @@
             <field name="inherit_id" ref="mrp.mrp_production_product_tree_view" />
             <field name="arch" type="xml">
                 <field name="product_uos" position="after">
-                    <field name="uop_id" class="oe_read_only"/>
-                    <field name="uop_qty" class="oe_read_only"/>
+                    <field name="uop_qty" groups="product.group_uos" class="oe_read_only"/>
+                    <field name="uop_id" groups="product.group_uos" class="oe_read_only"/>
                     <field name="uop_price" class="oe_read_only" />
                     <field name="supplier_id" />
                     <field name="cost" />
@@ -66,19 +66,19 @@
             <field name="inherit_id" ref="mrp.mrp_production_form_view" />
             <field name="arch" type="xml">
                 <field name="product_lines" position="after">
-                    <group class="oe_subtotal_footer oe_right">
-                        <field name="scheduled_total" invisible="1" />
-                        <label for="profit" />
+                    <group name="product_line_total_group" class="oe_subtotal_footer oe_right">
+                        <field name="scheduled_total" />
+                        <label for="scheduled_profit" />
                         <div>
-                            <field name="profit" class="oe_inline" />
+                            <field name="scheduled_profit" class="oe_inline" />
                             (<field name="profit_percent" class="oe_inline" /> %)
                         </div>
-                        <label for="commercial" />
+                        <field name="scheduled_cost_total" class="oe_subtotal_footer_separator" />
+                        <label for="scheduled_commercial" />
                         <div>
-                            <field name="commercial" class="oe_inline" />
+                            <field name="scheduled_commercial" class="oe_inline" />
                             (<field name="commercial_percent" class="oe_inline" /> %)
                         </div>
-                        <field name="cost_total" class="oe_subtotal_footer_separator" />
                         <div class="oe_subtotal_footer_separator oe_inline o_td_label">
                             <label for="production_total" />
                             <button name="button_recompute_total" states="draft"

--- a/mrp_supplier_price/views/res_config_view.xml
+++ b/mrp_supplier_price/views/res_config_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="mrp_config_settings_unitary">
+            <field name="name">mrp.config.settings.unitary</field>
+            <field name="model">mrp.config.settings</field>
+            <field name="inherit_id" ref="mrp.view_mrp_config" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='module_mrp_operations']/.." position="after">
+                    <div>
+                        <field name="subtotal_by_unit" class="oe_inline"/>
+                        <label for="subtotal_by_unit"/>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Manufacturing order / scheduled products view

Configurable computing, to have subtotal by produced unit or not:
![image](https://cloud.githubusercontent.com/assets/2323616/20359524/8fe0dd24-ac30-11e6-96ae-4662f8bf0792.png)

By unit
![image](https://cloud.githubusercontent.com/assets/2323616/20358133/edab4cf6-ac2a-11e6-9a60-6d378512c823.png)

Subtotal
![image](https://cloud.githubusercontent.com/assets/2323616/20381081/1a6cf728-aca6-11e6-829f-1d8be77a166e.png)
