### PR TITLE
[IMP] stock_account_payment_term: fixes #350

### DIFF
--- a/stock_account_payment_term/tests/test_picking_invoicing_date.py
+++ b/stock_account_payment_term/tests/test_picking_invoicing_date.py
@@ -33,7 +33,7 @@ class TestPickingInvoicingDate(common.TransactionCase):
         self.assertEqual(1, len(invoices))
         self.assertEqual(invoices.type, 'in_invoice')
         payday = self.partner.property_supplier_payment_term.line_ids[0].days
-        date = fields.Datetime.from_string(fields.Datetime.now()) + \
-            relativedelta(days=payday)
+        date = fields.Datetime.from_string(
+            fields.Date.context_today(invoices)) + relativedelta(days=payday)
         date_due = fields.Date.to_string(date)
         self.assertEqual(invoices.date_due, date_due)


### PR DESCRIPTION
avoid errors because of difference between user and server datetime