### PR TITLE
[MOD] product_variant_description: add test and get description on sale order line

### DIFF
--- a/product_variant_description/README.rst
+++ b/product_variant_description/README.rst
@@ -6,9 +6,9 @@
 Description on product variant
 ==============================
 
-With this module you will be able to define a different description
-for each product variant. There will be two fields, one in plaintext
-and other in html format.
+With this module you will be able to define a different description for each
+product variant. There will be two fields, one in plaintext and other in html
+format. This description will be shown on sale order line.
 
 Credits
 =======
@@ -17,4 +17,5 @@ Contributors
 ------------
 * Ana Juaristi <anajuaristi@avanzosc.es>
 * Alfredo de la Fuente <alfredodelafuente@avanzosc.es>
+* Esther Martín <esthermartin@avanzosc.es>
 

--- a/product_variant_description/__openerp__.py
+++ b/product_variant_description/__openerp__.py
@@ -10,10 +10,12 @@
     "contributors": [
         "Ana Juaristi <anajuaristi@avanzosc.es>",
         "Alfredo de la Fuente <alfredodelafuente@avanzosc.es>",
+        "Esther Martín <esthermartin@avanzosc.es>",
     ],
     "category": "Product Management",
     "depends": [
         "product",
+        "sale"
     ],
     "data": [
         "views/product_product_view.xml",

--- a/product_variant_description/models/__init__.py
+++ b/product_variant_description/models/__init__.py
@@ -2,3 +2,4 @@
 # (c) 2016 Alfredo de la Fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from . import product_product
+from . import sale_order

--- a/product_variant_description/models/product_product.py
+++ b/product_variant_description/models/product_product.py
@@ -7,6 +7,6 @@ from openerp import fields, models
 class ProductProduct(models.Model):
     _inherit = 'product.product'
 
-    variant_description = fields.Char(string='Description', translate=True)
+    variant_description = fields.Text(string='Description', translate=True)
     html_variant_description = fields.Html(
         string='HTML description', translate=True)

--- a/product_variant_description/models/sale_order.py
+++ b/product_variant_description/models/sale_order.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.multi
+    def product_id_change(
+            self, pricelist, product, qty=0, uom=False, qty_uos=0, uos=False,
+            name='', partner_id=False, lang=False, update_tax=True,
+            date_order=False, packaging=False, fiscal_position=False,
+            flag=False):
+        res = super(SaleOrderLine, self).product_id_change(
+            pricelist, product, qty=qty, uom=uom, qty_uos=qty_uos, uos=uos,
+            name=name, partner_id=partner_id, lang=lang, update_tax=update_tax,
+            date_order=date_order, packaging=packaging,
+            fiscal_position=fiscal_position, flag=flag)
+        if product:
+            lang = self.env['res.partner'].browse(partner_id).lang
+            product_o = self.env['product.product'].with_context(
+                lang=lang).browse(product)
+            if product_o.variant_description:
+                res['value']['name'] = \
+                    u'[{}] {}'.format(product_o.variant_description,
+                                     res['value']['name'])
+        return res

--- a/product_variant_description/models/sale_order.py
+++ b/product_variant_description/models/sale_order.py
@@ -26,5 +26,5 @@ class SaleOrderLine(models.Model):
             if product_o.variant_description:
                 res['value']['name'] = \
                     u'[{}] {}'.format(product_o.variant_description,
-                                     res['value']['name'])
+                                      res['value']['name'])
         return res

--- a/product_variant_description/tests/__init__.py
+++ b/product_variant_description/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import test_product_variant_description

--- a/product_variant_description/tests/test_product_variant_description.py
+++ b/product_variant_description/tests/test_product_variant_description.py
@@ -25,4 +25,4 @@ class TestProductVariantDescription(TransactionCase):
             fiscal_position=self.fp)
         self.assertEqual(
             u'[{}] {}'.format(product.variant_description,
-                             product.name), res['value']['name'])
+                              product.name), res['value']['name'])

--- a/product_variant_description/tests/test_product_variant_description.py
+++ b/product_variant_description/tests/test_product_variant_description.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Esther Martín - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp.tests.common import TransactionCase
+
+
+class TestProductVariantDescription(TransactionCase):
+
+    def setUp(self):
+        super(TestProductVariantDescription, self).setUp()
+        self.pricelist = self.ref('product.list0')
+        self.product_obj = self.env['product.product']
+        self.so_line_model = self.env['sale.order.line']
+        self.partner = self.ref('base.res_partner_1')
+        self.fp = self.ref('account.fiscal_position_normal_taxes_template1')
+
+    def test_product_id_change(self):
+        product = self.product_obj.create({
+            'name': 'Test product',
+            'variant_description': 'Product variant description test'
+        })
+        res = self.so_line_model.product_id_change(
+            self.pricelist, product.id, partner_id=self.partner,
+            fiscal_position=self.fp)
+        self.assertEqual(
+            u'[{}] {}'.format(product.variant_description,
+                             product.name), res['value']['name'])


### PR DESCRIPTION
1. variant_description debe ser de tipo text y no char.
 2. En el onchange del product_id en la línea de pedido de venta, además de la descripción de la plantilla debe traerse esta descripción. Concatenar las 2.  Primero la de la variante y luego la de la plantilla.
@avanzosc/developers review pls