### PR TITLE
[MOD] project_fix_price

### DIFF
--- a/project_fix_price/__openerp__.py
+++ b/project_fix_price/__openerp__.py
@@ -10,6 +10,7 @@
     "website": "http://www.avanzosc.es",
     "depends": [
         'project_task_ending',
+        'account_analytic_analysis'
     ],
     "contributors": [
         "Esther Martín <esthermartin@avanzosc.es>",
@@ -17,6 +18,7 @@
     "category": "Project Management",
     "data": [
         "security/ir.model.access.csv",
+        "data/product_data.xml",
         "views/invoice_mark_view.xml",
         "views/project_view.xml",
     ],

--- a/project_fix_price/data/product_data.xml
+++ b/project_fix_price/data/product_data.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record id="product_category_other_services" model="product.category">
+            <field name="name">Other Services</field>
+            <field name="parent_id" ref="product.product_category_all" />
+            <field name="type">normal</field>
+        </record>
+        <record id="product_product_for_project" model="product.product">
+            <field name="uom_id" ref="product.product_uom_hour"/>
+            <field name="uom_po_id" ref="product.product_uom_hour"/>
+            <field name="categ_id" ref="product_category_other_services"/>
+            <field name="type">service</field>
+            <field name="sale_ok" eval="True"/>
+            <field name="name">Project</field>
+        </record>
+        
+    </data>
+</openerp>

--- a/project_fix_price/i18n/es.po
+++ b/project_fix_price/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-03 12:47+0000\n"
-"PO-Revision-Date: 2017-03-03 13:52+0100\n"
+"POT-Creation-Date: 2017-03-16 12:47+0000\n"
+"PO-Revision-Date: 2017-03-16 13:58+0100\n"
 "Last-Translator: Esther Martín <esthermartin@avanzosc.es>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -22,12 +22,13 @@ msgid "Amount"
 msgstr "Importe"
 
 #. module: project_fix_price
-#: view:project.task:project_fix_price.project_edit_task_view_form
-msgid "Create invoice"
-msgstr "Crear factura"
+#: view:project.project:project_fix_price.project_invoice_mark_view_form
+#: view:project.task:project_fix_price.project_color_task_view_tree
+msgid "Close task & Create invoice"
+msgstr "Cerrar tarea & Crear factura"
 
 #. module: project_fix_price
-#: code:addons/project_fix_price/models/project.py:71
+#: code:addons/project_fix_price/models/project.py:91
 #, python-format
 msgid "Customer Invoices"
 msgstr "Facturas de Cliente"
@@ -39,14 +40,22 @@ msgid "Date end"
 msgstr "Fecha límite"
 
 #. module: project_fix_price
-#: code:addons/project_fix_price/models/project.py:67
-#, python-format
-msgid "Invoice created"
-msgstr "Factura creada"
+#: field:invoice.mark,display_name:0
+msgid "Display Name"
+msgstr "Mostrar Nombre"
+
+#. module: project_fix_price
+#: field:invoice.mark,invoice_id:0 field:project.task,invoice_id:0
+msgid "Invoice"
+msgstr "Factura"
+
+#. module: project_fix_price
+#: field:project.project,recurring_invoice_line_ids:0
+msgid "Invoice Lines"
+msgstr "Líneas de factura"
 
 #. module: project_fix_price
 #: view:project.task:project_fix_price.project_invoice_task_view_search
-#: field:project.task,invoiced:0
 msgid "Invoiced"
 msgstr "Facturado"
 
@@ -62,7 +71,6 @@ msgid "Is mark"
 msgstr "Es hito"
 
 #. module: project_fix_price
-#: view:invoice.mark:project_fix_price.invoice_mark_view_form
 #: view:invoice.mark:project_fix_price.invoice_mark_view_search
 #: view:invoice.mark:project_fix_price.invoice_mark_view_tree
 #: model:ir.actions.act_window,name:project_fix_price.action_view_invoice_mark
@@ -72,17 +80,20 @@ msgid "Marks"
 msgstr "Hitos"
 
 #. module: project_fix_price
-#: code:addons/project_fix_price/models/project.py:51
-#, python-format
-msgid "Nothing to invoice. Please create an invoice mark for this task: %s"
-msgstr ""
-"Nada para facturar. Por favor, crea un hito de facturación para esta tarea: "
-"%s"
+#: model:product.category,name:project_fix_price.product_category_other_services
+msgid "Other Services"
+msgstr "Otros Servicios"
 
 #. module: project_fix_price
 #: field:invoice.mark,percent:0
 msgid "Percent"
 msgstr "Porcentaje"
+
+#. module: project_fix_price
+#: code:addons/project_fix_price/models/project.py:46
+#, python-format
+msgid "Please define income account for product '%s'."
+msgstr "Por favor defina una cuenta de ingresos para el producto '%s'."
 
 #. module: project_fix_price
 #: field:invoice.mark,product_id:0
@@ -93,8 +104,14 @@ msgstr "Producto"
 #: view:invoice.mark:project_fix_price.invoice_mark_view_search
 #: field:invoice.mark,project_id:0
 #: model:ir.model,name:project_fix_price.model_project_project
+#: model:product.template,name:project_fix_price.product_product_for_project_product_template
 msgid "Project"
 msgstr "Proyecto"
+
+#. module: project_fix_price
+#: field:invoice.mark,stage_id:0
+msgid "Stage"
+msgstr "Etapa"
 
 #. module: project_fix_price
 #: view:invoice.mark:project_fix_price.invoice_mark_view_search
@@ -114,7 +131,7 @@ msgid "Tasks"
 msgstr "Tareas"
 
 #. module: project_fix_price
-#: code:addons/project_fix_price/models/project.py:42
+#: code:addons/project_fix_price/models/project.py:73
 #, python-format
 msgid ""
 "The project hasn't customer. If you want to invoice this task, please select "
@@ -124,10 +141,16 @@ msgstr ""
 "selecciona uno."
 
 #. module: project_fix_price
-#: code:addons/project_fix_price/models/project.py:46
+#: code:addons/project_fix_price/models/project.py:25
 #, python-format
-msgid "This task should be ended before making the invoice."
-msgstr "Esta tarea tiene que terminarse antes de facturarla."
+msgid "The sum of amount cant be greather than %s!"
+msgstr "La suma de los importes no puede ser superior a %s!"
+
+#. module: project_fix_price
+#: code:addons/project_fix_price/models/project.py:22
+#, python-format
+msgid "The sum of percent cant be greather than 100!"
+msgstr "La suma de los porcentajes no puede ser superior a 100!"
 
 #. module: project_fix_price
 #: view:project.task:project_fix_price.project_invoice_task_view_search
@@ -141,7 +164,11 @@ msgid "Total Amount"
 msgstr "Importe Total"
 
 #. module: project_fix_price
-#: view:invoice.mark:project_fix_price.invoice_mark_view_tree
-#: view:project.project:project_fix_price.project_invoice_mark_view_form
-msgid "Total Percent"
-msgstr "Porcentaje Total"
+#: help:project.project,amount_invoiced:0
+msgid "Total invoiced"
+msgstr "Total facturado"
+
+#. module: project_fix_price
+#: field:project.project,user_ids:0
+msgid "User"
+msgstr "Usuario"

--- a/project_fix_price/models/invoice_mark.py
+++ b/project_fix_price/models/invoice_mark.py
@@ -25,6 +25,21 @@ class InvoiceMark(models.Model):
         comodel_name='account.invoice', related='task_id.invoice_id')
 
     @api.multi
+    @api.onchange('percent')
+    def _onchange_percent(self):
+        for record in self:
+            amount_max = record.project_id.analytic_account_id.amount_max
+            record.amount = record.percent * amount_max / 100
+
+    @api.multi
+    @api.onchange('amount')
+    def _onchange_amount(self):
+        for record in self:
+            amount_max = record.project_id.analytic_account_id.amount_max
+            if amount_max > 0:
+                record.percent = (record.amount * 100) / amount_max
+
+    @api.multi
     def create_invoice(self):
         for mark in self:
             mark.task_id.create_invoice()

--- a/project_fix_price/tests/test_fix_price_project.py
+++ b/project_fix_price/tests/test_fix_price_project.py
@@ -44,13 +44,33 @@ class TestFixPriceProject(common.TransactionCase):
 
     def test_invoice_from_mark(self):
         self.task.project_id.partner_id = self.partner
+        analytic_id = self.task.project_id.analytic_account_id
+        analytic_id.fix_price_invoices = True
+        analytic_id.amount_max = 15000
         mark = self.mark_obj.create({
+            'project_id': self.task.project_id.id,
             'task_id': self.task.id,
             'product_id': self.product,
             'percent': 15,
-            'amount': 1500,
         })
         self.assertTrue(mark)
+        mark._onchange_percent()
+        self.assertEqual((analytic_id.amount_max * 15)/100, mark.amount)
+        mark.amount = 3000
+        mark._onchange_amount()
+        self.assertEqual(mark.amount*100/analytic_id.amount_max, mark.percent)
+        mark1 = self.mark_obj.create({
+            'project_id': self.task.project_id.id,
+            'task_id': self.task.id,
+            'product_id': self.product,
+            'percent': 90,
+        })
+        with self.assertRaises(exceptions.Warning):
+            self.task.project_id._check_mark_amount_and_percent()
+        mark1.percent = 30
+        mark1.amount = 13500
+        with self.assertRaises(exceptions.Warning):
+            self.task.project_id._check_mark_amount_and_percent()
         mark.create_invoice()
         self.assertEqual(mark.invoice_id, self.task.invoice_id)
         self.assertEqual(self.task.stage_id, self.end_stage)

--- a/project_fix_price/views/invoice_mark_view.xml
+++ b/project_fix_price/views/invoice_mark_view.xml
@@ -1,26 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
     <data>
-        <record id="invoice_mark_view_form" model="ir.ui.view">
-            <field name="name">invoice.mark.form</field>
-            <field name="model">invoice.mark</field>
-            <field name="arch" type="xml">
-                <form string="Marks">
-                    <group col="4" colspan="8">
-                        <group>
-                            <field name="project_id" />
-                            <field name="task_id" required="1" domain="[('project_id', '=', project_id)]"/>
-                            <field name="product_id" required="1"/>
-                            <field name="date_end" readonly="1"/>
-                        </group>
-                        <group>
-                            <field name="percent" />
-                            <field name="amount" />
-                        </group>
-                    </group>
-                </form>
-            </field>
-        </record>
         <record id="invoice_mark_view_tree" model="ir.ui.view">
             <field name="name">invoice.mark.tree</field>
             <field name="model">invoice.mark</field>

--- a/project_fix_price/views/project_view.xml
+++ b/project_fix_price/views/project_view.xml
@@ -47,10 +47,10 @@
             <field name="arch" type="xml">
                 <notebook position="inside">
                     <page string="Invoicing Mark">
-                        <field name="mark_ids" context="{'default_project_id': active_id}">
+                        <field name="mark_ids" context="{'default_project_id': active_id, 'default_product_id': %(project_fix_price.product_product_for_project)d}">
                             <tree editable="top">
                                 <field name="project_id" invisible="1" />
-                                <field name="task_id" domain="[('project_id','=',project_id),('invoice_id','=',False)]" required="1"/>
+                                <field name="task_id" domain="[('project_id','=',project_id),('invoice_id','=',False)]" context="{'default_project_id': project_id}" required="1"/>
                                 <field name="stage_id" readonly="1"/>
                                 <field name="product_id" required="1"/>
                                 <field name="date_end" readonly="1"/>


### PR DESCRIPTION
- Recalcular al cambiar el porcentaje o el importe
- Arrastrar más datos a la factura
- Al crear una tarea lleve el proyecto correcto asignado
- Crear producto y asignarlo por defecto a la tabla de hitos de facturación
- Recoger el proyecto, si el hito de facturación se está creando desde el propio proyecto
- Controlar que el porcentaje de los hitos no supere el 100%
- Controlar que el importe de los hitos no supere el precio fijo previsto de la cuenta analítica