### PR TITLE
[ADD] product_training_plan: Define training plan in produts.

### DIFF
--- a/product_training_plan/README.rst
+++ b/product_training_plan/README.rst
@@ -1,0 +1,17 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=====================
+Product training plan
+=====================
+
+* Define training plan in products, and products template.s
+
+Credits
+=======
+
+Contributors
+------------
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/product_training_plan/__init__.py
+++ b/product_training_plan/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import models

--- a/product_training_plan/__openerp__.py
+++ b/product_training_plan/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Product Training Plan",
+    "version": "8.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Alfredo de la Fuente <alfredodelafuente@avanzosc.es",
+    ],
+    "category": "Sales Management",
+    "depends": [
+        "product",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/product_product_view.xml",
+    ],
+    "installable": True,
+}

--- a/product_training_plan/i18n/es.po
+++ b/product_training_plan/i18n/es.po
@@ -1,0 +1,162 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* product_training_plan
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-16 14:47+0000\n"
+"PO-Revision-Date: 2017-03-16 15:50+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: product_training_plan
+#: field:product.event.track.template,create_uid:0
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: product_training_plan
+#: field:product.event.track.template,create_date:0
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: product_training_plan
+#: field:product.event.track.template,html_info:0
+#: field:product.event.track.template,name:0
+msgid "Description"
+msgstr "Descripción"
+
+#. module: product_training_plan
+#: field:product.event.track.template,display_name:0
+msgid "Display Name"
+msgstr "Mostrar nombre"
+
+#. module: product_training_plan
+#: field:product.event.track.template,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: product_training_plan
+#: field:product.event.track.template,__last_update:0
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: product_training_plan
+#: field:product.event.track.template,write_uid:0
+msgid "Last Updated by"
+msgstr "Última modificación por"
+
+#. module: product_training_plan
+#: field:product.event.track.template,write_date:0
+msgid "Last Updated on"
+msgstr "Última modificación el"
+
+#. module: product_training_plan
+#: field:product.product,purchase_line_warn_msg:0
+msgid "Message for Purchase Order Line"
+msgstr "Mensaje para línea pedido de compra"
+
+#. module: product_training_plan
+#: field:product.product,sale_line_warn_msg:0
+msgid "Message for Sales Order Line"
+msgstr "Mensaje para línea pedido de venta"
+
+#. module: product_training_plan
+#: sql_constraint:product.event.track.template:0
+msgid ""
+"No puede crear dos plantillas con la misma secuencia para una plantilla de "
+"producto/producto."
+msgstr ""
+"No puede crear dos plantillas con la misma secuencia para una plantilla de "
+"producto/producto."
+
+#. module: product_training_plan
+#: field:product.event.track.template,planification:0
+msgid "Planification"
+msgstr "Planificación"
+
+#. module: product_training_plan
+#: model:ir.model,name:product_training_plan.model_product_product
+#: field:product.event.track.template,product_id:0
+msgid "Product"
+msgstr "Producto"
+
+#. module: product_training_plan
+#: model:ir.model,name:product_training_plan.model_product_template
+msgid "Product Template"
+msgstr "Plantilla de producto"
+
+#. module: product_training_plan
+#: field:product.event.track.template,product_tmpl_id:0
+msgid "Product template"
+msgstr "Plantilla producto"
+
+#. module: product_training_plan
+#: field:product.product,purchase_line_warn:0
+msgid "Purchase Order Line"
+msgstr "Línea pedido de compra"
+
+#. module: product_training_plan
+#: field:product.event.track.template,resolution:0
+msgid "Resolution"
+msgstr "Resolución"
+
+#. module: product_training_plan
+#: view:product.product:product_training_plan.product_product_track_info_form_view
+msgid "Sales"
+msgstr "Ventas"
+
+#. module: product_training_plan
+#: field:product.product,sale_line_warn:0
+msgid "Sales Order Line"
+msgstr "Línea pedido de venta"
+
+#. module: product_training_plan
+#: field:product.event.track.template,sequence:0
+msgid "Sequence"
+msgstr "Secuencia"
+
+#. module: product_training_plan
+#: help:product.product,purchase_line_warn:0
+#: help:product.product,sale_line_warn:0
+msgid ""
+"Si selecciona la opción \"Aviso\" se notificará a los usuarios con el "
+"mensaje, si selecciona \"Mensaje de bloqueo\" se lanzará una excepción con "
+"el mensaje y se bloqueará el flujo. El mensaje debe escribirse en el "
+"siguiente campo."
+msgstr ""
+"Si selecciona la opción \"Aviso\" se notificará a los usuarios con el "
+"mensaje, si selecciona \"Mensaje de bloqueo\" se lanzará una excepción con "
+"el mensaje y se bloqueará el flujo. El mensaje debe escribirse en el "
+"siguiente campo."
+
+#. module: product_training_plan
+#: model:ir.model,name:product_training_plan.model_product_event_track_template
+#: view:product.product:product_training_plan.product_product_track_info_form_view
+#: field:product.product,event_track_template2_ids:0
+#: field:product.product,event_track_template_ids:0
+#: view:product.template:product_training_plan.product_template_only_form_view_inh_track_info
+#: field:product.template,event_track_template2_ids:0
+msgid "Training plan"
+msgstr "Plan formación"
+
+#. module: product_training_plan
+#: field:product.event.track.template,url:0
+msgid "URL"
+msgstr "URL"
+
+#. module: product_training_plan
+#: code:addons/product_training_plan/models/product.py:43
+#, python-format
+msgid ""
+"You can not create two templates with same sequence for one product template/"
+"product."
+msgstr ""
+"No puede crear 2 planes de formación con la misma secuenda para un producto "
+"plantilla/producto."

--- a/product_training_plan/models/__init__.py
+++ b/product_training_plan/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import product

--- a/product_training_plan/models/product.py
+++ b/product_training_plan/models/product.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import fields, models, _
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    event_track_template2_ids = fields.One2many(
+        comodel_name='product.event.track.template', copy=True,
+        inverse_name='product_tmpl_id', string='Training plan')
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    event_track_template_ids = fields.One2many(
+        comodel_name='product.event.track.template', inverse_name='product_id',
+        string='Training plan', copy=True)
+
+
+class ProductEventTrackTemplate(models.Model):
+    _name = 'product.event.track.template'
+    _description = 'Training plan'
+    _rec_name = 'product_id'
+    _order = 'product_tmpl_id, product_id, sequence asc'
+
+    product_tmpl_id = fields.Many2one(
+        comodel_name='product.template', string='Product template')
+    product_id = fields.Many2one(
+        comodel_name='product.product', string='Product')
+    sequence = fields.Integer(string="Sequence")
+    name = fields.Char(string="Description")
+    planification = fields.Text(string="Planification")
+    resolution = fields.Text(string="Resolution")
+    html_info = fields.Html(string='Description', translate=True)
+    url = fields.Char(string='URL')
+
+    _sql_constraints = [
+        ('track_template_product_unique', 'unique(product_tmpl_id, product_id,'
+         ' sequence)',
+         _('You can not create two templates with same sequence for one'
+           ' product template/product.'))
+    ]

--- a/product_training_plan/security/ir.model.access.csv
+++ b/product_training_plan/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_product_event_track_template_manager","product_event_track_template","product_training_plan.model_product_event_track_template","base.group_sale_manager",1,1,1,1
+"access_product_event_track_template_user","product_event_track_template","product_training_plan.model_product_event_track_template","base.group_user",1,1,1,1
+

--- a/product_training_plan/views/product_product_view.xml
+++ b/product_training_plan/views/product_product_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="product_product_track_info_form_view" model="ir.ui.view">
+            <field name="name">product.product.track_info.form</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_normal_form_view"/>
+            <field name="arch" type="xml">
+                <page string="Sales" position="after">
+                    <page string="Training plan">
+                        <field name="event_track_template_ids" nolabel="1"
+                               context="{'default_product_id':active_id, 'default_product_tmpl_id':product_tmpl_id}" />
+                    </page>
+                </page>
+            </field>
+        </record>
+        <record id="product_template_only_form_view_inh_track_info" model="ir.ui.view">
+            <field name="name">product.template.only.form.view.inh.track.info</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_only_form_view"/>
+            <field name="arch" type="xml">
+                <page name="variants" position="after">
+                    <page string="Training plan">
+                        <field name="event_track_template2_ids" nolabel="1"
+                               context="{'default_product_tmpl_id':active_id}" />
+                    </page>
+                </page>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Nuevo módulo para definir planes de formación, en plantillas de productos, y variantes de productos.
Esta programación se ha quitado del módulo "event_track_info", para poder ser utilizado en pedidos de venta.