### PR TITLE
[IMP] stock_quant_relocate: Not show quants of products with route "M…

### DIFF
--- a/stock_quant_relocate/i18n/es.po
+++ b/stock_quant_relocate/i18n/es.po
@@ -102,3 +102,11 @@ msgstr "El tipo de albarán determina la vista de albarán"
 #: view:product.template:stock_quant_relocate.product_template_search_view_inh_relocate
 msgid "Type"
 msgstr "Tipo"
+
+#. module: stock_quant_relocate
+#: view:stock.quant.move:stock_quant_relocate.stock_quant_move_wizard_inh_relocate
+msgid "Quants of products with route \"Make to order\" will not be displayed"
+msgstr ""
+"No se mostrarán quants de productos con método de abastecimiento \"Bajo "
+"pedido\" "
+

--- a/stock_quant_relocate/tests/test_stock_quant_relocate.py
+++ b/stock_quant_relocate/tests/test_stock_quant_relocate.py
@@ -24,6 +24,8 @@ class TestStockQuantRelocate(common.TransactionCase):
         product = picking.move_lines[0].product_id
         product.default_location = self.ref('stock.location_gate_b')
         res = picking.button_relocate()
+        product.categ_id.default_location = self.ref('stock.location_gate_b')
+        res = picking.button_relocate()
         context = res.get('context', False)
         self.assertNotEqual(context, False, 'Error in call button_relocate')
         self.assertEqual(context.get('active_model', False), 'stock.quant',

--- a/stock_quant_relocate/wizard/quant_move_wizard.py
+++ b/stock_quant_relocate/wizard/quant_move_wizard.py
@@ -20,15 +20,18 @@ class StockQuantMove(models.TransientModel):
     def _catch_product_default_location(self, res):
         quant_obj = self.env['stock.quant']
         res['picking_id'] = self.env.context.get('picking_id')
+        pack = []
         lines = res.get('pack_move_items', False)
         for line in lines:
             if line.get('quant', False):
                 quant = quant_obj.browse(line.get('quant'))
-                if quant.product_id.default_location:
-                    line['dest_loc'] = quant.product_id.default_location.id
-                elif quant.product_id.categ_id.default_location:
+                if not quant.reservation_id:
                     line['dest_loc'] = (
-                        quant.product_id.categ_id.default_location.id)
+                        quant.product_id.default_location.id or
+                        quant.product_id.categ_id.default_location.id or
+                        False)
+                    pack.append(line)
+        res['pack_move_items'] = pack
         return res
 
     @api.one

--- a/stock_quant_relocate/wizard/quant_move_wizard_view.xml
+++ b/stock_quant_relocate/wizard/quant_move_wizard_view.xml
@@ -9,6 +9,11 @@
                 <field name="dest_loc" position="attributes">
                     <attribute name="required">1</attribute>
                 </field>
+                <xpath expr="//form[@string='Transfer details']/group" position="before">
+                    <header>
+                        <h3>Quants of products with route "Make to order" will not be displayed</h3>
+                    </header>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
…ake to order".
Módulo modificado para no mostrar en el wizard quants con moves de productos con método de suministro "Bajo pedido".