### PR TITLE
[FIX] sale_order_training_plan: Dont catch resolution, and catch plan…

### DIFF
--- a/sale_order_training_plan/models/sale_order_line.py
+++ b/sale_order_training_plan/models/sale_order_line.py
@@ -39,5 +39,5 @@ class SaleOrderLine(models.Model):
         for template in templates:
             line += u'{}.- {}: {}.\n\n'.format(
                     template.sequence, template.training_plan_id.name,
-                    template.training_plan_id.resolution)
+                    template.training_plan_id.planification)
         return line


### PR DESCRIPTION
…ification from training plan.
Coger el campo "planification" en vez de coger el campo "resolution" de planes de formación.