### PR TITLE
[FIX] contract_school: when multiple percentage and multiple taxes used redo calculations

### DIFF
--- a/contract_school/models/__init__.py
+++ b/contract_school/models/__init__.py
@@ -1,3 +1,4 @@
+from . import account_invoice
 from . import account_invoice_line
 from . import contract_contract
 from . import contract_line

--- a/contract_school/models/account_invoice.py
+++ b/contract_school/models/account_invoice.py
@@ -1,0 +1,18 @@
+# Copyright 2019 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    def _prepare_tax_line_vals(self, line, tax):
+        vals = super(AccountInvoice, self)._prepare_tax_line_vals(line, tax)
+        if line.payment_percentage:
+            percentage = line.payment_percentage / 100
+            vals.update({
+                'base': vals['base'] * percentage,
+                'amount': vals['amount'] * percentage,
+            })
+        return vals

--- a/contract_school/models/account_invoice_line.py
+++ b/contract_school/models/account_invoice_line.py
@@ -8,25 +8,17 @@ class AccountInvoiceLine(models.Model):
 
     payment_percentage = fields.Float(string='Payment %', default=100.0)
 
-    @api.one
     @api.depends('price_unit', 'discount', 'invoice_line_tax_ids', 'quantity',
                  'product_id', 'invoice_id.partner_id',
                  'invoice_id.currency_id', 'invoice_id.company_id',
                  'invoice_id.date_invoice', 'invoice_id.date',
                  'payment_percentage')
     def _compute_price(self):
-        super(AccountInvoiceLine, self)._compute_price()
-        if self.payment_percentage > 0 and self.payment_percentage != 100.0:
-            if self.price_subtotal:
-                self.price_subtotal = (
-                    self.price_subtotal * self.payment_percentage) / 100
-            if self.price_subtotal_signed:
-                self.price_subtotal_signed = (
-                    self.price_subtotal_signed * self.payment_percentage) / 100
-            if self.price_total:
-                self.price_total = (
-                    self.price_total * self.payment_percentage) / 100
-            for line in self.invoice_id.tax_line_ids:
-                line.amount_total = (
-                    line.amount_total * self.payment_percentage) / 100
-            self.invoice_id._compute_amount()
+        for line in self:
+            super(AccountInvoiceLine, line)._compute_price()
+            if (line.payment_percentage > 0 and
+                    line.payment_percentage != 100.0):
+                percentage = line.payment_percentage / 100.0
+                line.price_subtotal *= percentage
+                line.price_subtotal_signed *= percentage
+                line.price_total *= percentage

--- a/contract_school/tests/test_contract_school.py
+++ b/contract_school/tests/test_contract_school.py
@@ -13,10 +13,11 @@ class TestContractSchool(common.SavepointCase):
     def setUpClass(cls):
         super(TestContractSchool, cls).setUpClass()
         cls.product_model = cls.env['product.product']
-        cls.account_model = cls.env['contract.contract']
+        cls.contract_model = cls.env['contract.contract']
         cls.line_model = cls.env['contract.line']
         cls.partner_model = cls.env['res.partner']
         cls.invoice_model = cls.env['account.invoice']
+        cls.tax_model = cls.env['account.tax']
         today = fields.Date.from_string(fields.Date.today())
         start = today + relativedelta(months=-1)
         end = today + relativedelta(months=+1)
@@ -24,19 +25,38 @@ class TestContractSchool(common.SavepointCase):
             'name': 'Family for test sale_crm_school',
             'educational_category': 'family',
         }
+        cls.tax_10 = cls.tax_model.create({
+            'name': '10% Tax',
+            'amount_type': 'percent',
+            'amount': 10,
+        })
+        cls.tax_20 = cls.tax_model.create({
+            'name': '20% Tax',
+            'amount_type': 'percent',
+            'amount': 20,
+        })
         cls.family = cls.partner_model.create(family_vals)
-        cls.product = cls.product_model.search([], limit=1)
-        account_vals = {
+        cls.product1 = cls.product_model.create({
+            'name': 'Test Service 10%',
+            'type': 'service',
+            'taxes_id': [(6, 0, cls.tax_10.ids)],
+        })
+        cls.product2 = cls.product_model.create({
+            'name': 'Test Product 20%',
+            'type': 'product',
+            'taxes_id': [(6, 0, cls.tax_20.ids)],
+        })
+        contract_vals = {
             'name': 'Contract for test contract_school',
             'partner_id': cls.family.id,
             'contract_type': 'sale',
         }
-        cls.account = cls.account_model.create(account_vals)
+        cls.contract = cls.contract_model.create(contract_vals)
         line_vals = {
-            'contract_id': cls.account.id,
-            'product_id': cls.product.id,
-            'name': cls.product.name,
-            'uom_id': cls.product.uom_id.id,
+            'contract_id': cls.contract.id,
+            'product_id': cls.product1.id,
+            'name': cls.product1.name,
+            'uom_id': cls.product1.uom_id.id,
             'recurring_next_date': today,
             'date_start': start,
             'date_end': end,
@@ -50,6 +70,8 @@ class TestContractSchool(common.SavepointCase):
         cls.line2 = cls.line.copy()
         cls.line2._onchange_product_id()
         cls.line2.write({
+            'product_id': cls.product2.id,
+            'name': cls.product2.name,
             'price_unit': 200,
             'payment_percentage': 100.0,
             'recurring_next_date': start,
@@ -64,17 +86,42 @@ class TestContractSchool(common.SavepointCase):
         })
 
     def test_contract_school(self):
-        for line in self.account.contract_line_ids:
+        for line in self.contract.contract_line_ids:
             subtotal = line.quantity * line.price_unit
-            discount = line.discount / 100
-            subtotal *= 1 - discount
+            subtotal *= (1 - (line.discount / 100))
             subtotal *= line.payment_percentage / 100
             self.assertEquals(line.price_subtotal, subtotal)
-        self.account_model.cron_recurring_create_invoice()
-        invoices = self.account._get_related_invoices()
+        self.contract_model.cron_recurring_create_invoice()
+        invoices = self.contract._get_related_invoices()
         self.assertEquals(len(invoices), 1)
-        self.assertEquals(len(invoices[0].invoice_line_ids), 2)
+        invoice = invoices[:1]
+        self.assertEquals(invoice.amount_untaxed, 600)
+        self.assertEquals(invoice.amount_tax, 80)
+        self.assertEquals(invoice.amount_total, 680)
+        self.assertEquals(len(invoice.invoice_line_ids), 2)
+        invoice_line = invoice.invoice_line_ids[:1]
+        self.assertEquals(invoice_line.payment_percentage, 50.0)
+        self.assertEquals(invoice_line.price_subtotal_signed, 400.0)
+        self.assertEquals(invoice_line.price_subtotal, 400.0)
+        self.assertEquals(invoice_line.price_total, 440.0)
+        self.assertEquals(invoice_line.price_tax, 40.0)
+        self.assertEquals(len(invoice.tax_line_ids), 2)
+        tax_line = invoice.tax_line_ids.filtered(
+            lambda l: l.tax_id in invoice_line.invoice_line_tax_ids)
+        self.assertEquals(tax_line.amount, invoice_line.price_tax)
+        self.assertEquals(tax_line.base, invoice_line.price_subtotal)
         self.assertEquals(
-            invoices[0].invoice_line_ids[0].payment_percentage, 50.0)
+            invoice.amount_untaxed,
+            sum(invoice.mapped('invoice_line_ids.price_subtotal')))
         self.assertEquals(
-            invoices[0].invoice_line_ids[0].price_subtotal, 400.0)
+            invoice.amount_untaxed,
+            sum(invoice.mapped('tax_line_ids.base')))
+        self.assertEquals(
+            invoice.amount_tax,
+            sum(invoice.mapped('invoice_line_ids.price_tax')))
+        self.assertEquals(
+            invoice.amount_tax,
+            sum(invoice.mapped('tax_line_ids.amount')))
+        self.assertEquals(
+            invoice.amount_total,
+            sum(invoice.mapped('invoice_line_ids.price_total')))


### PR DESCRIPTION
Factura inicial de prueba:
![image](https://user-images.githubusercontent.com/2323616/68945699-42d3bd00-07b1-11ea-8bf7-730fb3b54271.png)

![image](https://user-images.githubusercontent.com/2323616/68945724-55e68d00-07b1-11ea-87ef-1aac33b783e1.png)

La suma de los totales de la segunda tabla debería de ser igual a los impuestos de la factura.