### PR TITLE
[FIX] stock_move_utilities: Fix product form.

### DIFF
--- a/stock_move_utilities/__openerp__.py
+++ b/stock_move_utilities/__openerp__.py
@@ -3,7 +3,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Stock Move Utilities",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.1.0",
     "license": "AGPL-3",
     "depends": [
         "stock",

--- a/stock_move_utilities/views/product_views.xml
+++ b/stock_move_utilities/views/product_views.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
-        <record id="view_template_property_form_inh_utilities" model="ir.ui.view">
+        <record id="product_template_form_view_inh_utilities" model="ir.ui.view">
             <field name="model">product.product</field>
             <field name="mode">primary</field>
             <field eval="7" name="priority"/>
-            <field name="inherit_id" ref="stock.view_template_property_form"/>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
-                <field name="virtual_available" position="after">
-                    <field name="reserved"/>
-                </field>
+                <group name="status" position="before">
+                    <group name="reserved">
+                        <field name="reserved"/>
+                    </group>
+                    <group></group>
+                </group>
             </field>
         </record>
     </data>

--- a/stock_move_utilities/views/stock_move_utilities_views.xml
+++ b/stock_move_utilities/views/stock_move_utilities_views.xml
@@ -24,5 +24,27 @@
             </field>
           </field>
         </record>
+        <record id="view_move_form_inh_utilities" model="ir.ui.view">
+          <field name="model">stock.move</field>
+          <field name="inherit_id" ref="stock.view_move_form"/>
+          <field name="arch" type="xml">
+            <group name="origin_grp" position="before">
+                <group name="group-price" colspan="4">
+                    <field name="price_unit" />
+                    <field name="price_subtotal" />
+                </group>
+            </group>
+          </field>
+        </record>
+        <record id="view_move_tree_inh_utilities" model="ir.ui.view">
+          <field name="model">stock.move</field>
+          <field name="inherit_id" ref="stock.view_move_tree"/>
+          <field name="arch" type="xml">
+            <field name="location_id"  position="before">
+                <field name="price_unit" />
+                <field name="price_subtotal" />
+            </field>
+          </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
El formulario de productos estaba mal heredado, se habían perdido los atajos.
Además se muestran los campo "price_unit" y "price_subtotal" en el tree y form de moviemientos de stoc.