### PR TITLE
[ADD] website_event_track_claim_multiple_advice:  In crm claim catego…

### DIFF
--- a/website_event_track_claim_multiple_advice/README.rst
+++ b/website_event_track_claim_multiple_advice/README.rst
@@ -1,0 +1,31 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+=========================================
+Website event track claim multiple advice
+=========================================
+
+* In crm claim category new field "Number of consecutive fouls".
+* When claims of this type are created in a participant of an event session
+  with this number of consecutive sessions, an email will be sent to the
+  responsible of the event.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/avanzosc/odoo-addons/issues>`_. In case of trouble,
+please check there if your issue has already been reported. If you spotted
+it first, help us smash it by providing detailed and welcomed feedback.
+
+Do not contact contributors directly about support or help with technical issues.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/website_event_track_claim_multiple_advice/__init__.py
+++ b/website_event_track_claim_multiple_advice/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/website_event_track_claim_multiple_advice/__manifest__.py
+++ b/website_event_track_claim_multiple_advice/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Website Event Track Claim Multiple Advice",
+    "version": '14.0.1.0.0',
+    "author": "Avanzosc",
+    "license": "AGPL-3",
+    "category": "Marketing/Events",
+    "website": "http://www.avanzosc.es",
+    "depends": [
+        "crm_claim",
+        "website_event_track_claim",
+    ],
+    "data": [
+        'data/website_event_track_claim_multiple_advice_data.xml',
+        'views/crm_claim_category_views.xml'
+    ],
+    "installable": True,
+}

--- a/website_event_track_claim_multiple_advice/data/website_event_track_claim_multiple_advice_data.xml
+++ b/website_event_track_claim_multiple_advice/data/website_event_track_claim_multiple_advice_data.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<odoo noupdate="1">
+    <record id="student_with_multiple_advice_mail" model="mail.template">
+        <field name="name">Student with multiple advice</field>
+        <field name="model_id" ref="crm_claim.model_crm_claim"/>
+        <field name="subject">Student ${object.partner_id.name} with ${object.categ_id.number_of_consecutive_fouls} consecutive claims.</field>
+        <field name="partner_to">${object.partner_responsible_id != False and object.partner_responsible_id.id}</field>
+        <!-- 
+        <field name="email_to">${(not object.partner_id and object.email_from)|safe}</field>
+        -->
+        <field name="body_html"></field>
+        <field name="lang">${object.partner_responsible_id.lang}</field>
+        <field name="auto_delete" eval="True"/>
+        <field name="body_html" type="html">
+            <div style="margin: 0px; padding: 0px;">
+                <p style="margin: 0px; padding: 0px; font-size: 13px;">
+                    Dear ${object.partner_responsible_id.name}.
+                    <br/><br/>
+                    The student ${object.partner_id.name} attending event ${object.event_id.name}, has ${object.categ_id.number_of_consecutive_fouls} consecutive claims for these sessions: ${object.tracks_names}. 
+                    <br/><br/>
+                    Regards.
+                </p>
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/website_event_track_claim_multiple_advice/i18n/es.po
+++ b/website_event_track_claim_multiple_advice/i18n/es.po
@@ -1,0 +1,117 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* website_event_track_claim_multiple_advice
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-02-22 11:52+0000\n"
+"PO-Revision-Date: 2022-02-22 11:52+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: website_event_track_claim_multiple_advice
+#: model:mail.template,body_html:website_event_track_claim_multiple_advice.student_with_multiple_advice_mail
+msgid ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
+"                    Dear ${object.partner_responsible_id.name}.\n"
+"                    <br/><br/>\n"
+"                    The student ${object.partner_id.name} attending event ${object.event_id.name}, has ${object.categ_id.number_of_consecutive_fouls} consecutive claims for these sessions: ${object.tracks_names}. \n"
+"                    <br/><br/>\n"
+"                    Regards.\n"
+"                </p>\n"
+"            </div>\n"
+"        "
+msgstr ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
+"                    Estimado ${object.partner_responsible_id.name}.\n"
+"                    <br/><br/>\n"
+"                    El/La estudiante ${object.partner_id.name} que asiste al evento ${object.event_id.name}, tiene ${object.categ_id.number_of_consecutive_fouls} reclamaciones consecutivas para estas sesiones: ${object.tracks_names}. \n"
+"                    <br/><br/>\n"
+"                    Saludos.\n"
+"                </p>\n"
+"            </div>\n"
+"        "
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model,name:website_event_track_claim_multiple_advice.model_crm_claim_category
+msgid "Category of claim"
+msgstr "Categoría de la reclamación"
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model,name:website_event_track_claim_multiple_advice.model_crm_claim
+msgid "Claim"
+msgstr "Reclamación"
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim__display_name
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim_category__display_name
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_wiz_event_participant_create_claim__display_name
+msgid "Display Name"
+msgstr "Nombre para mostrar"
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim__id
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim_category__id
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_wiz_event_participant_create_claim__id
+msgid "ID"
+msgstr "Identificador"
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim____last_update
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim_category____last_update
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_wiz_event_participant_create_claim____last_update
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim_category__number_of_consecutive_fouls
+msgid "Number of consecutive fouls"
+msgstr "Número de faltas consecutivas "
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,help:website_event_track_claim_multiple_advice.field_crm_claim__partner_responsible_id
+msgid "Partner-related data of the user"
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim__partner_responsible_id
+msgid "Responsible"
+msgstr "Responsable"
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim__tracks_names
+msgid "Sessions description"
+msgstr "Descripción sesiones"
+
+#. module: website_event_track_claim_multiple_advice
+#: model:mail.template,subject:website_event_track_claim_multiple_advice.student_with_multiple_advice_mail
+msgid ""
+"Student ${object.partner_id.name} with "
+"${object.categ_id.number_of_consecutive_fouls} consecutive claims."
+msgstr ""
+"Estudiante ${object.partner_id.name} con "
+"${object.categ_id.number_of_consecutive_fouls} reclamaciones consecutivas."
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,help:website_event_track_claim_multiple_advice.field_crm_claim_category__number_of_consecutive_fouls
+msgid ""
+"When claims of this type are created in a participant of an event session "
+"with this number of consecutive sessions, an email will be sent to the "
+"person in charge of the event."
+msgstr ""
+"Cuando con este número de sesiones consecutivas se creen reclamaciones "
+"de este tipo en un participante de una sesión de evento, se enviará un "
+"correo al responsable del evento."
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model,name:website_event_track_claim_multiple_advice.model_wiz_event_participant_create_claim
+msgid "Wizard for create event participant claim"
+msgstr "Asistente para crear reclamación participante"

--- a/website_event_track_claim_multiple_advice/i18n/website_event_track_claim_multiple_advice.pot
+++ b/website_event_track_claim_multiple_advice/i18n/website_event_track_claim_multiple_advice.pot
@@ -1,0 +1,102 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* website_event_track_claim_multiple_advice
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-02-22 11:51+0000\n"
+"PO-Revision-Date: 2022-02-22 11:51+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: website_event_track_claim_multiple_advice
+#: model:mail.template,body_html:website_event_track_claim_multiple_advice.student_with_multiple_advice_mail
+msgid ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                <p style=\"margin: 0px; padding: 0px; font-size: 13px;\">\n"
+"                    Dear ${object.partner_responsible_id.name}.\n"
+"                    <br/><br/>\n"
+"                    The student ${object.partner_id.name} attending event ${object.event_id.name}, has ${object.categ_id.number_of_consecutive_fouls} consecutive claims for these sessions: ${object.tracks_names}. \n"
+"                    <br/><br/>\n"
+"                    Regards.\n"
+"                </p>\n"
+"            </div>\n"
+"        "
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model,name:website_event_track_claim_multiple_advice.model_crm_claim_category
+msgid "Category of claim"
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model,name:website_event_track_claim_multiple_advice.model_crm_claim
+msgid "Claim"
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim__display_name
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim_category__display_name
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_wiz_event_participant_create_claim__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim__id
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim_category__id
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_wiz_event_participant_create_claim__id
+msgid "ID"
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim____last_update
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim_category____last_update
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_wiz_event_participant_create_claim____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim_category__number_of_consecutive_fouls
+msgid "Number of consecutive fouls"
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,help:website_event_track_claim_multiple_advice.field_crm_claim__partner_responsible_id
+msgid "Partner-related data of the user"
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim__partner_responsible_id
+msgid "Responsible"
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,field_description:website_event_track_claim_multiple_advice.field_crm_claim__tracks_names
+msgid "Sessions description"
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:mail.template,subject:website_event_track_claim_multiple_advice.student_with_multiple_advice_mail
+msgid ""
+"Student ${object.partner_id.name} with "
+"${object.categ_id.number_of_consecutive_fouls} consecutive claims."
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model.fields,help:website_event_track_claim_multiple_advice.field_crm_claim_category__number_of_consecutive_fouls
+msgid ""
+"When claims of this type are created in a participant of an event session "
+"with this number of consecutive sessions, an email will be sent to the "
+"person in charge of the event."
+msgstr ""
+
+#. module: website_event_track_claim_multiple_advice
+#: model:ir.model,name:website_event_track_claim_multiple_advice.model_wiz_event_participant_create_claim
+msgid "Wizard for create event participant claim"
+msgstr ""

--- a/website_event_track_claim_multiple_advice/models/__init__.py
+++ b/website_event_track_claim_multiple_advice/models/__init__.py
@@ -1,0 +1,2 @@
+from . import crm_claim_category
+from . import crm_claim

--- a/website_event_track_claim_multiple_advice/models/crm_claim.py
+++ b/website_event_track_claim_multiple_advice/models/crm_claim.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from odoo import models, fields
+
+
+class CrmClaim(models.Model):
+    _inherit = 'crm.claim'
+
+    partner_responsible_id = fields.Many2one(
+        string='Responsible', related='event_responsible_id.partner_id',
+        store=True)
+    tracks_names = fields.Char(string='Sessions description')
+
+    def send_to_responsible_notification_multiple_advice(self, tracks_names):
+        mail_template = self.env.ref(
+            "website_event_track_claim_multiple_advice.student_with_multiple"
+            "_advice_mail")
+        for claim in self:
+            claim.tracks_names = tracks_names
+            mail_template.send_mail(claim.id, force_send=True)

--- a/website_event_track_claim_multiple_advice/models/crm_claim_category.py
+++ b/website_event_track_claim_multiple_advice/models/crm_claim_category.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from odoo import models, fields
+
+
+class CrmClaimCategory(models.Model):
+    _inherit = 'crm.claim.category'
+
+    number_of_consecutive_fouls = fields.Integer(
+        string='Number of consecutive fouls', default=0,
+        help='When claims of this type are created in a participant of an '
+        'event session with this number of consecutive sessions, an email will'
+        ' be sent to the person in charge of the event.')

--- a/website_event_track_claim_multiple_advice/views/crm_claim_category_views.xml
+++ b/website_event_track_claim_multiple_advice/views/crm_claim_category_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record model="ir.ui.view" id="crm_claim_category_tree">
+        <field name="model">crm.claim.category</field>
+        <field name="inherit_id" ref="crm_claim.crm_claim_category_tree"/>
+        <field name="arch" type="xml">
+            <field name="team_id" position="after">
+                <field name="number_of_consecutive_fouls"/>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="crm_claim_category_form">
+        <field name="model">crm.claim.category</field>
+        <field name="inherit_id" ref="crm_claim.crm_claim_category_form"/>
+        <field name="arch" type="xml">
+            <field name="team_id" position="after">
+                <field name="number_of_consecutive_fouls"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/website_event_track_claim_multiple_advice/wizard/__init__.py
+++ b/website_event_track_claim_multiple_advice/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import wiz_event_participant_create_claim

--- a/website_event_track_claim_multiple_advice/wizard/wiz_event_participant_create_claim.py
+++ b/website_event_track_claim_multiple_advice/wizard/wiz_event_participant_create_claim.py
@@ -1,0 +1,42 @@
+# Copyright 2022 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class WizEventRegistrationCancelParticipant(models.TransientModel):
+    _inherit = 'wiz.event.participant.create.claim'
+
+    def action_create_claim(self):
+        self.ensure_one()
+        claim_obj = self.env['crm.claim']
+        result = super(
+            WizEventRegistrationCancelParticipant, self).action_create_claim()
+        partners = self.env['res.partner'].browse(
+            self.env.context.get('active_ids'))
+        if not self.categ_id.number_of_consecutive_fouls:
+            return result
+        for partner in partners:
+            cond = [('categ_id', '=', self.categ_id.id),
+                    ('partner_id', '=', partner.id),
+                    ('event_id', '=', self.event_track_id.event_id.id),
+                    ('event_track_id', '=', self.event_track_id.id)]
+            claim = claim_obj.search(cond, limit=1)
+            track = self.event_track_id.id
+            tracks_names = self.event_track_id.name
+            number = 1
+            while (claim and number !=
+                    self.categ_id.number_of_consecutive_fouls):
+                track -= 1
+                cond = [('categ_id', '=', self.categ_id.id),
+                        ('partner_id', '=', partner.id),
+                        ('event_id', '=', self.event_track_id.event_id.id),
+                        ('event_track_id', '=', track)]
+                claim = claim_obj.search(cond, limit=1)
+                if claim:
+                    tracks_names = u'{}, {}'.format(
+                        tracks_names, claim.event_track_id.name)
+                    number += 1
+            if number == self.categ_id.number_of_consecutive_fouls:
+                claim.send_to_responsible_notification_multiple_advice(
+                    tracks_names)
+        return result


### PR DESCRIPTION
…ry new field "Number of consecutive fouls".

When claims of this type are created in a participant of an event session  with this number of consecutive sessions, an email will be sent to the responsible of the event.
@avanzosc/developers ... review please