### PR TITLE
[FIX] event_track_cancel_reason: Arreglar mensaje de error "No puedes…

### DIFF
--- a/event_track_cancel_reason/wizard/event_track_cancel_wizard.py
+++ b/event_track_cancel_reason/wizard/event_track_cancel_wizard.py
@@ -66,7 +66,7 @@ class EventTrackCancelWizard(models.TransientModel):
         if not line:
             track._create_analytic_line()
             if self.time_type_id.customer_billable is False:
-                analytic_line = self.env['account.analytic.line'].search(
-                    cond, limit=1)
+                analytic_line = self.sudo().env[
+                    'account.analytic.line'].search(cond, limit=1)
                 if analytic_line:
-                    analytic_line.non_allow_billable = True
+                    analytic_line.sudo().non_allow_billable = True


### PR DESCRIPTION
… acceder a partes de horas que no son tuyos".