### PR TITLE
[16.0][MIG] stock_move_line_force_done: Migration to 16.0

### DIFF
--- a/setup/stock_move_line_force_done/odoo/addons/stock_move_line_force_done
+++ b/setup/stock_move_line_force_done/odoo/addons/stock_move_line_force_done
@@ -1,0 +1,1 @@
+../../../../stock_move_line_force_done

--- a/setup/stock_move_line_force_done/setup.py
+++ b/setup/stock_move_line_force_done/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_move_line_force_done/README.rst
+++ b/stock_move_line_force_done/README.rst
@@ -1,0 +1,31 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+==========================
+Stock move line force done
+==========================
+
+* New button in pickings "Force done detailed operations". This module sets in
+  detailed operations the "Done" field equal to the amount requested in
+  operations. If the detailed operation of the operation does not exist, it is
+  created automatically. 
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/avanzosc/odoo-addons/issues>`_. In case of trouble,
+please check there if your issue has already been reported. If you spotted
+it first, help us smash it by providing detailed and welcomed feedback.
+
+Do not contact contributors directly about support or help with technical issues.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Alfredo de la Fuente <alfredodelafuente@avanzosc.es>

--- a/stock_move_line_force_done/__init__.py
+++ b/stock_move_line_force_done/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_move_line_force_done/__manifest__.py
+++ b/stock_move_line_force_done/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+{
+    "name": "Stock Move Line Force Done",
+    "version": "12.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "category": "Warehouse",
+    "depends": [
+        "stock"
+    ],
+    "data": [
+        "views/stock_picking_view.xml",
+    ],
+    "installable": True,
+}

--- a/stock_move_line_force_done/__manifest__.py
+++ b/stock_move_line_force_done/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 {
     "name": "Stock Move Line Force Done",
-    "version": "12.0.1.0.0",
+    "version": "16.0.1.0.0",
     "license": "AGPL-3",
     "author": "AvanzOSC",
     "website": "https://github.com/avanzosc/odoo-addons",

--- a/stock_move_line_force_done/__manifest__.py
+++ b/stock_move_line_force_done/__manifest__.py
@@ -5,11 +5,9 @@
     "version": "12.0.1.0.0",
     "license": "AGPL-3",
     "author": "AvanzOSC",
-    "website": "http://www.avanzosc.es",
+    "website": "https://github.com/avanzosc/odoo-addons",
     "category": "Warehouse",
-    "depends": [
-        "stock"
-    ],
+    "depends": ["stock"],
     "data": [
         "views/stock_picking_view.xml",
     ],

--- a/stock_move_line_force_done/__manifest__.py
+++ b/stock_move_line_force_done/__manifest__.py
@@ -5,7 +5,7 @@
     "version": "16.0.1.0.0",
     "license": "AGPL-3",
     "author": "AvanzOSC",
-    "website": "https://github.com/avanzosc/odoo-addons",
+    "website": "http://www.avanzosc.es",
     "category": "Warehouse",
     "depends": ["stock"],
     "data": [

--- a/stock_move_line_force_done/i18n/es.po
+++ b/stock_move_line_force_done/i18n/es.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_move_line_force_done
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-14 08:40+0000\n"
+"PO-Revision-Date: 2022-03-14 08:40+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_move_line_force_done
+#: model_terms:ir.ui.view,arch_db:stock_move_line_force_done.view_picking_form
+msgid "Force done detailed operations"
+msgstr "Forzar realizadas operaciones detalladas"
+
+#. module: stock_move_line_force_done
+#: model:ir.model,name:stock_move_line_force_done.model_stock_picking
+msgid "Transfer"
+msgstr "Transferir"
+

--- a/stock_move_line_force_done/i18n/stock_move_line_force_done.pot
+++ b/stock_move_line_force_done/i18n/stock_move_line_force_done.pot
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* stock_move_line_force_done
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-14 08:40+0000\n"
+"PO-Revision-Date: 2022-03-14 08:40+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_move_line_force_done
+#: model_terms:ir.ui.view,arch_db:stock_move_line_force_done.view_picking_form
+msgid "Force done detailed operations"
+msgstr ""
+
+#. module: stock_move_line_force_done
+#: model:ir.model,name:stock_move_line_force_done.model_stock_picking
+msgid "Transfer"
+msgstr ""
+

--- a/stock_move_line_force_done/models/__init__.py
+++ b/stock_move_line_force_done/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_picking
+from . import stock_quant

--- a/stock_move_line_force_done/models/stock_picking.py
+++ b/stock_move_line_force_done/models/stock_picking.py
@@ -1,0 +1,23 @@
+# Copyright 2022 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from odoo import models, api
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    @api.multi
+    def button_force_done_detailed_operations(self):
+        for picking in self:
+            for move in picking.move_ids_without_package:
+                lines = picking.move_line_ids_without_package.filtered(
+                    lambda x: not x.move_id)
+                if lines:
+                    lines.unlink()
+                line = picking.move_line_ids_without_package.filtered(
+                    lambda x: x.move_id == move)
+                if not line:
+                    line = self.env['stock.move.line'].create(
+                        move._prepare_move_line_vals())
+                if line and line.qty_done != move.product_uom_qty:
+                    line.qty_done = move.product_uom_qty

--- a/stock_move_line_force_done/models/stock_picking.py
+++ b/stock_move_line_force_done/models/stock_picking.py
@@ -1,23 +1,26 @@
 # Copyright 2022 Alfredo de la Fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-from odoo import models, api
+from odoo import api, models
 
 
 class StockPicking(models.Model):
-    _inherit = 'stock.picking'
+    _inherit = "stock.picking"
 
     @api.multi
     def button_force_done_detailed_operations(self):
         for picking in self:
             for move in picking.move_ids_without_package:
                 lines = picking.move_line_ids_without_package.filtered(
-                    lambda x: not x.move_id)
+                    lambda x: not x.move_id
+                )
                 if lines:
                     lines.unlink()
                 line = picking.move_line_ids_without_package.filtered(
-                    lambda x: x.move_id == move)
+                    lambda x: x.move_id == move
+                )
                 if not line:
-                    line = self.env['stock.move.line'].create(
-                        move._prepare_move_line_vals())
+                    line = self.env["stock.move.line"].create(
+                        move._prepare_move_line_vals()
+                    )
                 if line and line.qty_done != move.product_uom_qty:
                     line.qty_done = move.product_uom_qty

--- a/stock_move_line_force_done/models/stock_picking.py
+++ b/stock_move_line_force_done/models/stock_picking.py
@@ -6,7 +6,6 @@ from odoo import api, models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    @api.multi
     def button_force_done_detailed_operations(self):
         for picking in self:
             for move in picking.move_ids_without_package:

--- a/stock_move_line_force_done/models/stock_quant.py
+++ b/stock_move_line_force_done/models/stock_quant.py
@@ -1,0 +1,31 @@
+# Copyright 2022 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from odoo import models, api
+from odoo.tools.float_utils import float_compare
+
+
+class StockQuant(models.Model):
+    _inherit = 'stock.quant'
+
+    @api.model
+    def _update_reserved_quantity(self, product_id, location_id, quantity,
+                                  lot_id=None, package_id=None, owner_id=None,
+                                  strict=False):
+        self = self.sudo()
+        rounding = product_id.uom_id.rounding
+        quants = self._gather(
+            product_id, location_id, lot_id=lot_id, package_id=package_id,
+            owner_id=owner_id, strict=strict)
+        if float_compare(quantity, 0, precision_rounding=rounding) < 0:
+            available_quantity = sum(quants.mapped('reserved_quantity'))
+            if float_compare(
+                abs(quantity), available_quantity,
+                    precision_rounding=rounding) > 0:
+                if len(quants) == 1:
+                    if quantity < 0:
+                        quantity = quantity * -1
+                    my_quantity = available_quantity + quantity
+                    quants.write({'reserved_quantity': my_quantity})
+        return super(StockQuant, self)._update_reserved_quantity(
+            product_id, location_id, quantity, lot_id=lot_id,
+            package_id=package_id, owner_id=owner_id, strict=strict)

--- a/stock_move_line_force_done/models/stock_quant.py
+++ b/stock_move_line_force_done/models/stock_quant.py
@@ -1,31 +1,52 @@
 # Copyright 2022 Alfredo de la Fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-from odoo import models, api
+from odoo import api, models
 from odoo.tools.float_utils import float_compare
 
 
 class StockQuant(models.Model):
-    _inherit = 'stock.quant'
+    _inherit = "stock.quant"
 
     @api.model
-    def _update_reserved_quantity(self, product_id, location_id, quantity,
-                                  lot_id=None, package_id=None, owner_id=None,
-                                  strict=False):
+    def _update_reserved_quantity(
+        self,
+        product_id,
+        location_id,
+        quantity,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+    ):
         self = self.sudo()
         rounding = product_id.uom_id.rounding
         quants = self._gather(
-            product_id, location_id, lot_id=lot_id, package_id=package_id,
-            owner_id=owner_id, strict=strict)
+            product_id,
+            location_id,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )
         if float_compare(quantity, 0, precision_rounding=rounding) < 0:
-            available_quantity = sum(quants.mapped('reserved_quantity'))
-            if float_compare(
-                abs(quantity), available_quantity,
-                    precision_rounding=rounding) > 0:
+            available_quantity = sum(quants.mapped("reserved_quantity"))
+            if (
+                float_compare(
+                    abs(quantity), available_quantity, precision_rounding=rounding
+                )
+                > 0
+            ):
                 if len(quants) == 1:
                     if quantity < 0:
                         quantity = quantity * -1
                     my_quantity = available_quantity + quantity
-                    quants.write({'reserved_quantity': my_quantity})
-        return super(StockQuant, self)._update_reserved_quantity(
-            product_id, location_id, quantity, lot_id=lot_id,
-            package_id=package_id, owner_id=owner_id, strict=strict)
+                    quants.write({"reserved_quantity": my_quantity})
+        return super()._update_reserved_quantity(
+            product_id,
+            location_id,
+            quantity,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )

--- a/stock_move_line_force_done/views/stock_picking_view.xml
+++ b/stock_move_line_force_done/views/stock_picking_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="view_picking_form" >
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="arch" type="xml">
+            <button name="action_assign" position="after">
+                <button name="button_force_done_detailed_operations"
+                    attrs="{'invisible': ['|', ('state', 'not in', ('waiting', 'confirmed')), ('show_validate', '=', False)]}"
+                    string="Force done detailed operations" type="object"
+                    groups="stock.group_stock_user" class="o_btn_validate"/>
+            </button>
+        </field>
+    </record>
+</odoo>

--- a/stock_move_line_force_done/views/stock_picking_view.xml
+++ b/stock_move_line_force_done/views/stock_picking_view.xml
@@ -1,14 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
-    <record model="ir.ui.view" id="view_picking_form" >
+    <record model="ir.ui.view" id="view_picking_form">
         <field name="model">stock.picking</field>
-        <field name="inherit_id" ref="stock.view_picking_form"/>
+        <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
             <button name="action_assign" position="after">
-                <button name="button_force_done_detailed_operations"
-                    attrs="{'invisible': ['|', ('state', 'not in', ('waiting', 'confirmed')), ('show_validate', '=', False)]}"
-                    string="Force done detailed operations" type="object"
-                    groups="stock.group_stock_user" class="o_btn_validate"/>
+                <button
+          name="button_force_done_detailed_operations"
+          attrs="{'invisible': ['|', ('state', 'not in', ('waiting', 'confirmed')), ('show_validate', '=', False)]}"
+          string="Force done detailed operations"
+          type="object"
+          groups="stock.group_stock_user"
+          class="o_btn_validate"
+        />
             </button>
         </field>
     </record>

--- a/stock_move_line_qty_domain/__manifest__.py
+++ b/stock_move_line_qty_domain/__manifest__.py
@@ -5,7 +5,7 @@
     "version": "16.0.1.0.0",
     "license": "AGPL-3",
     "author": "AvanzOSC",
-    "website": "http://www.avanzosc.es",
+    "website": "https://github.com/avanzosc/odoo-addons",
     "category": "Warehouse",
     "depends": ["stock"],
     "data": [],

--- a/stock_quant_calculate_packaging/__manifest__.py
+++ b/stock_quant_calculate_packaging/__manifest__.py
@@ -6,7 +6,7 @@
     "category": "Sales/Sales",
     "license": "AGPL-3",
     "author": "https://github.com/avanzosc/odoo-addons",
-    "website": "http://www.avanzosc.es",
+    "website": "https://github.com/avanzosc/odoo-addons",
     "depends": ["product", "stock"],
     "data": [
         "views/stock_quant_views.xml",


### PR DESCRIPTION
New button in pickings "Force done detailed operations". This module sets in
  detailed operations the "Done" field equal to the amount requested in
  operations. If the detailed operation of the operation does not exist, it is
  created automatically. 