### PR TITLE
stock_picking_cancel: remove valuation layer

### DIFF
--- a/stock_picking_cancel/models/stock_move.py
+++ b/stock_picking_cancel/models/stock_move.py
@@ -4,12 +4,15 @@ from odoo import models
 
 
 class StockMove(models.Model):
-    _inherit = 'stock.move'
+    _inherit = "stock.move"
 
     def do_cancel_done(self):
         for move in self:
-            move.state = 'draft'
+            move.state = "draft"
             for move_line in move.move_line_ids:
                 move_line._refresh_quants_by_picking_cancelation()
             move._do_unreserve()
             move.move_line_ids.unlink()
+        # If stock_account is installed, drop the stock_valuation_layer_ids
+        if "stock_valuation_layer_ids" in self._fields:
+            move.sudo().stock_valuation_layer_ids.unlink()


### PR DESCRIPTION
Hi @alfredoavanzosc @anajuaristi 

After testing this module, I realize that the stock valuation was not delete when cancelling a stock.picking.
As this module do not depend on stock_account, I make the deletation conditionnal

An alternative will be to 
- add stock_account as dependency
- or moving the deletation part in a dedicated module

Tell me what do you prefer.

Thanks

@florian-dacosta @bguillot @paradoxxxzero maybe this can interest you 
