### PR TITLE
[16.0][FIX] product_auto_reordering_rule: Change "warehout_id" by "wa…

### DIFF
--- a/product_auto_reordering_rule/models/product_product.py
+++ b/product_auto_reordering_rule/models/product_product.py
@@ -41,7 +41,7 @@ class ProductProduct(models.Model):
     def _catch_values_create_orderpoint(self, warehouse, location):
         vals = {
             "product_id": self.id,
-            "warehout_id": warehouse.id,
+            "warehouse_id": warehouse.id,
             "location_id": location.id,
             "product_min_qty": 0,
             "product_max_qty": 0,


### PR DESCRIPTION
…rehouse_id".