### PR TITLE
[14.0][IMP] stock_inventory_at_date: Set default `product_id` in `cre…

### DIFF
--- a/stock_inventory_at_date/models/stock_inventory_line.py
+++ b/stock_inventory_at_date/models/stock_inventory_line.py
@@ -14,6 +14,10 @@ class StockInventoryLine(models.Model):
             if "inventory_id" in group:
                 inventory = self.env["stock.inventory"].browse(group["inventory_id"])
                 today = date.today()
+                if "product_id" not in group:
+                    default_product_id = self.env.context.get("default_product_id")
+                    if default_product_id:
+                        group["product_id"] = default_product_id
                 if (
                     inventory
                     and (inventory.accounting_date)


### PR DESCRIPTION
…ate` to avoid errors from read only views.

When creating a stock inventory line from a view where `product_id` is readonly, the field is not included in `vals_list`, which may lead to validation errors. This update ensures `product_id` is properly set during creation, improving robustness in such cases.

