### PR TITLE
[14.0][FIX] stock_picking_package_usability: Remove fields packaging_…

### DIFF
--- a/stock_picking_package_usability/views/stock_move_line_views.xml
+++ b/stock_picking_package_usability/views/stock_move_line_views.xml
@@ -11,9 +11,7 @@
                 <attribute name="domain">[('picking_id','=',picking_id)]</attribute>
             </field>
             <field name="result_package_id" position="after">
-                <field name="packaging_id" optional="show" />
                 <field name="line_weight" string="Peso línea" />
-                <field name="manual_pack_weight" />
                 <field name="weight_uom_name" string=" " />
             </field>
         </field>


### PR DESCRIPTION
…id and manual_pack_weight from stock.move.line views