### PR TITLE
[16.0][FIX] account_invoice_accounting_date_equal_bill_date: fix null date when duplicating vendor invoice.

### DIFF
--- a/account_invoice_accounting_date_equal_bill_date/models/account_move.py
+++ b/account_invoice_accounting_date_equal_bill_date/models/account_move.py
@@ -17,8 +17,12 @@ class AccountMove(models.Model):
             lambda x: x.move_type in ("in_invoice", "in_refund")
         )
         other_moves = self - supplier_moves
-        if other_moves:
-            result = super(AccountMove, other_moves)._compute_date()
-        for move in supplier_moves:
+        supplier_moves_with_date = supplier_moves.filtered("invoice_date")
+        supplier_moves_without_date = supplier_moves - supplier_moves_with_date
+        if other_moves or supplier_moves_without_date:
+            result = super(
+                AccountMove, other_moves | supplier_moves_without_date
+            )._compute_date()
+        for move in supplier_moves_with_date:
             move.date = move.invoice_date
         return result


### PR DESCRIPTION
When duplicating a vendor invoice (in_invoice / in_refund), the _compute_date
override assigns move.date = move.invoice_date unconditionally for supplier
moves. Since invoice_date has copy=False, it is False in the duplicated record,
which causes date to also be False, violating the NOT NULL constraint on
account_move.date.

Fix: split supplier moves into two groups:
- Those with invoice_date: keep existing behavior (date = invoice_date)
- Those without invoice_date (e.g. during duplication): delegate to super(),
  which falls back to today's date per standard Odoo behavior.

Steps to reproduce:
1. Open any posted vendor invoice
2. Action > Duplicate
3. Error: NotNullViolation: null value in column "date" violates not-null constraint