### PR TITLE
[18.0][IMP] purchase_order_shipping_method: State field store true

### DIFF
--- a/purchase_order_shipping_method/models/transport_carrier_lines_to_invoice.py
+++ b/purchase_order_shipping_method/models/transport_carrier_lines_to_invoice.py
@@ -18,6 +18,7 @@ class TransportCarrierLinesToInvoice(models.Model):
         string="Status",
         compute="_compute_state",
         copy=False,
+        store=True,
     )
     transfer_id = fields.Many2one(string="Transfer", comodel_name="stock.picking")
     transporter_id = fields.Many2one(string="Transporter", comodel_name="res.partner")
@@ -66,6 +67,7 @@ class TransportCarrierLinesToInvoice(models.Model):
         readonly=True,
     )
 
+    @api.depends("supplier_invoice_id")
     def _compute_state(self):
         for line in self:
             line.state = "to_invoice"


### PR DESCRIPTION
Port of CLM15056 from 14.0 to 18.0.

Original PR: https://github.com/avanzosc/odoo-addons/pull/4008

Changes:
- Store `transport.carrier.lines.to.invoice.state` so it can be searched/grouped reliably.
- Add the compute dependency on `supplier_invoice_id` so the stored value recomputes when billing state changes.

Validation:
- `python3 -m py_compile purchase_order_shipping_method/models/transport_carrier_lines_to_invoice.py`
- `pre-commit run --files purchase_order_shipping_method/models/transport_carrier_lines_to_invoice.py`